### PR TITLE
Setup initial compiler driver and basic mlir boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ target/
 .env
 .vscode/
 lcov.info
+
+build_artifacts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,60 @@ checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anstream"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "ascii-canvas"
@@ -27,10 +87,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.47",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.47",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -60,14 +181,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "comrak"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f18e72341e6cdc7489cffb76f993812a14a906db54dedb020044ccc211dcaae"
+dependencies = [
+ "clap",
+ "derive_builder",
+ "entities",
+ "memchr",
+ "once_cell",
+ "regex",
+ "shell-words",
+ "slug",
+ "syntect",
+ "typed-arena",
+ "unicode_categories",
+ "xdg",
+]
+
+[[package]]
 name = "concrete"
 version = "0.1.0"
+dependencies = [
+ "concrete_driver",
+]
 
 [[package]]
 name = "concrete_ast"
@@ -79,10 +305,28 @@ dependencies = [
 [[package]]
 name = "concrete_codegen_mlir"
 version = "0.1.0"
+dependencies = [
+ "cc",
+ "concrete_ast",
+ "concrete_session",
+ "llvm-sys",
+ "melior",
+ "mlir-sys",
+ "tracing",
+]
 
 [[package]]
 name = "concrete_driver"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "concrete_ast",
+ "concrete_codegen_mlir",
+ "concrete_parser",
+ "concrete_session",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "concrete_parser"
@@ -97,14 +341,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "concrete_session"
+version = "0.1.0"
+
+[[package]]
 name = "concrete_type_checker"
 version = "0.1.0"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deunicode"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
 
 [[package]]
 name = "diff"
@@ -149,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +527,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -169,6 +545,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -188,16 +574,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -217,7 +630,7 @@ checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -228,6 +641,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lalrpop"
@@ -262,10 +681,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "libredox"
@@ -279,10 +720,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "llvm-sys"
+version = "170.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed90f72df5504c0af2e3a08ee7762a4a3e42ec2605811fc19f64879de40c50a"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
 
 [[package]]
 name = "lock_api"
@@ -320,7 +790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -333,10 +803,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "melior"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634f33663d2bcac794409829caf83a08967249e5429f34ec20c92230a85c025a"
+dependencies = [
+ "dashmap",
+ "melior-macro",
+ "mlir-sys",
+ "once_cell",
+]
+
+[[package]]
+name = "melior-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9339fd6934926500d5a5f378bb5cda44efe33c74e4c300f083bf89b1544005"
+dependencies = [
+ "comrak",
+ "convert_case",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.47",
+ "tblgen",
+ "unindent",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mlir-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e19a5391ed2759fd9060f538330b9b89191e7b13503d7499a4f9580af6699a"
+dependencies = [
+ "bindgen 0.68.1",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -345,10 +877,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -378,6 +958,18 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "petgraph"
@@ -411,10 +1003,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+
+[[package]]
+name = "plist"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.47",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -423,6 +1051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -462,8 +1099,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.3",
  "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -476,6 +1122,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "regex-syntax"
@@ -496,6 +1148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,7 +1163,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -515,16 +1173,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+
+[[package]]
+name = "serde"
+version = "1.0.195"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.195"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "slug"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd94acec9c8da640005f8e135a39fc0372e74535e6b368b7a04b875f784c8c4"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "smallvec"
@@ -546,6 +1293,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +1321,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02b4b303bf8d08bfeb0445cba5068a3d306b6baece1d5582171a9bf49188f91"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax 0.7.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
+name = "tblgen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d19c09266feb8b16718d1183044d14703a0b4b59e55ce8beb4d6e21dd066b1b"
+dependencies = [
+ "bindgen 0.66.1",
+ "cc",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +1363,16 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -584,7 +1392,46 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -615,7 +1462,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -625,7 +1472,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
@@ -634,16 +1517,122 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "winapi"
@@ -662,10 +1651,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -789,3 +1796,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = [ "crates/concrete","crates/concrete_ast", "crates/concrete_codegen_mlir", "crates/concrete_driver", "crates/concrete_parser", "crates/concrete_type_checker"]
+members = [ "crates/concrete","crates/concrete_ast", "crates/concrete_codegen_mlir", "crates/concrete_driver", "crates/concrete_parser", "crates/concrete_session", "crates/concrete_type_checker"]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ If building LLVM from source, you'll need additional tools:
 - cmake 3.13.4 or later
 - libstdc++-static may be required on some Linux distributions such as Fedora and Ubuntu
 
+Setup the following env vars:
+```bash
+# For Debian/Ubuntu using the repository, the path will be /usr/lib/llvm-17
+export MLIR_SYS_170_PREFIX=/usr/lib/llvm-17
+export LLVM_SYS_170_PREFIX=/usr/lib/llvm-17
+export TABLEGEN_170_PREFIX=/usr/lib/llvm-17
+```
+
 ## Table of Contents
 
 - [Design](#design)
@@ -55,7 +63,7 @@ Concrete take many features from Rust like:
 - Expressions and statements rather than only expressions as in many functional languages
 - Built-in dependency manager
 - Built-in linter and formatter
-- Built-in testing tooling 
+- Built-in testing tooling
 - Good compilation error messages
 - Inmutability by default, optional mutability
 

--- a/crates/concrete/src/main.rs
+++ b/crates/concrete/src/main.rs
@@ -1,3 +1,5 @@
-fn main() {
-    println!("Hello, world!");
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    concrete_driver::main()
 }

--- a/crates/concrete_ast/src/lib.rs
+++ b/crates/concrete_ast/src/lib.rs
@@ -1,3 +1,5 @@
+use modules::Module;
+
 pub mod common;
 pub mod constants;
 pub mod expressions;
@@ -8,3 +10,8 @@ pub mod operations;
 pub mod statements;
 pub mod structs;
 pub mod types;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Program {
+    pub modules: Vec<Module>,
+}

--- a/crates/concrete_ast/src/modules.rs
+++ b/crates/concrete_ast/src/modules.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ModuleBase {
+pub struct Module {
     pub doc_string: Option<DocString>,
     pub imports: Vec<ImportStmt>,
     pub name: Ident,

--- a/crates/concrete_codegen_mlir/Cargo.toml
+++ b/crates/concrete_codegen_mlir/Cargo.toml
@@ -6,3 +6,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+concrete_ast = { path = "../concrete_ast"}
+concrete_session = { path = "../concrete_session"}
+llvm-sys = "170.0.1"
+melior = { version = "0.15.0", features = ["ods-dialects"] }
+mlir-sys = "0.2.1"
+tracing.workspace = true
+
+[build-dependencies]
+cc = "1.0.83"

--- a/crates/concrete_codegen_mlir/build.rs
+++ b/crates/concrete_codegen_mlir/build.rs
@@ -1,0 +1,16 @@
+use std::env::var;
+
+fn main() {
+    let mlir_path = var("MLIR_SYS_170_PREFIX").expect("MLIR path should be set.");
+
+    cc::Build::new()
+        .cpp(true)
+        .flag("-std=c++17")
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-comment")
+        .include(&format!("{mlir_path}/include"))
+        .file("src/wrappers.cpp")
+        .compile("ffi");
+
+    println!("cargo:rerun-if-changed=src/wrappers.cpp");
+}

--- a/crates/concrete_codegen_mlir/src/codegen.rs
+++ b/crates/concrete_codegen_mlir/src/codegen.rs
@@ -1,0 +1,52 @@
+use super::error::CompilerError;
+use concrete_ast::{modules::Module, Program};
+use melior::{
+    dialect::func,
+    ir::{
+        attribute::{StringAttribute, TypeAttribute},
+        r#type::FunctionType,
+        Block, Location, Module as MeliorModule, Region,
+    },
+    Context as MeliorContext,
+};
+
+/// Setup _start and call into main.
+pub fn compile_start(ctx: &MeliorContext, mlir_module: &MeliorModule, _entry_point_symbol: &str) {
+    let location = Location::unknown(ctx);
+    let region = Region::new();
+    let block = region.append_block(Block::new(&[]));
+
+    // TODO: implement
+    // Note: _start should return nothing.
+
+    block.append_operation(func::r#return(&[], location));
+
+    mlir_module.body().append_operation(func::func(
+        ctx,
+        StringAttribute::new(ctx, "_start"),
+        TypeAttribute::new(FunctionType::new(ctx, &[], &[]).into()),
+        region,
+        &[],
+        location,
+    ));
+}
+
+pub fn compile_program(
+    ctx: &MeliorContext,
+    mlir_module: &MeliorModule,
+    program: &Program,
+) -> Result<(), CompilerError> {
+    for module in &program.modules {
+        compile_module(ctx, mlir_module, module)?;
+    }
+    Ok(())
+}
+
+fn compile_module(
+    _ctx: &MeliorContext,
+    _mlir_module: &MeliorModule,
+    _module: &Module,
+) -> Result<(), CompilerError> {
+    // todo!()
+    Ok(())
+}

--- a/crates/concrete_codegen_mlir/src/codegen.rs
+++ b/crates/concrete_codegen_mlir/src/codegen.rs
@@ -1,35 +1,6 @@
 use super::error::CompilerError;
 use concrete_ast::{modules::Module, Program};
-use melior::{
-    dialect::func,
-    ir::{
-        attribute::{StringAttribute, TypeAttribute},
-        r#type::FunctionType,
-        Block, Location, Module as MeliorModule, Region,
-    },
-    Context as MeliorContext,
-};
-
-/// Setup _start and call into main.
-pub fn compile_start(ctx: &MeliorContext, mlir_module: &MeliorModule, _entry_point_symbol: &str) {
-    let location = Location::unknown(ctx);
-    let region = Region::new();
-    let block = region.append_block(Block::new(&[]));
-
-    // TODO: implement
-    // Note: _start should return nothing.
-
-    block.append_operation(func::r#return(&[], location));
-
-    mlir_module.body().append_operation(func::func(
-        ctx,
-        StringAttribute::new(ctx, "_start"),
-        TypeAttribute::new(FunctionType::new(ctx, &[], &[]).into()),
-        region,
-        &[],
-        location,
-    ));
-}
+use melior::{ir::Module as MeliorModule, Context as MeliorContext};
 
 pub fn compile_program(
     ctx: &MeliorContext,

--- a/crates/concrete_codegen_mlir/src/context.rs
+++ b/crates/concrete_codegen_mlir/src/context.rs
@@ -1,0 +1,69 @@
+use concrete_ast::Program;
+use concrete_session::Session;
+use melior::{
+    dialect::DialectRegistry,
+    ir::{Location, Module as MeliorModule},
+    utility::{register_all_dialects, register_all_llvm_translations, register_all_passes},
+    Context as MeliorContext,
+};
+
+use super::{error::CompilerError, module::MLIRModule, pass_manager::run_pass_manager};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Context {
+    melior_context: MeliorContext,
+}
+
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Context {
+    pub fn new() -> Self {
+        let melior_context = initialize_mlir();
+        Self { melior_context }
+    }
+
+    /// Compiles an Austral program into MLIR and then lowers to LLVM.
+    /// Returns the corresponding Module struct.
+    pub fn compile(
+        &self,
+        session: &Session,
+        program: &Program,
+    ) -> Result<MLIRModule, CompilerError> {
+        let file_path = session.file_path.display().to_string();
+        let location = Location::new(&self.melior_context, &file_path, 0, 0);
+
+        let mut melior_module = MeliorModule::new(location);
+
+        if !session.library {
+            super::codegen::compile_start(&self.melior_context, &melior_module, "main");
+        }
+
+        super::codegen::compile_program(&self.melior_context, &melior_module, program)?;
+
+        // TODO: Add proper error handling.
+        run_pass_manager(&self.melior_context, &mut melior_module).unwrap();
+
+        Ok(MLIRModule::new(melior_module))
+    }
+}
+
+/// Initialize an MLIR context.
+pub fn initialize_mlir() -> MeliorContext {
+    let context = MeliorContext::new();
+    context.append_dialect_registry(&{
+        let registry = DialectRegistry::new();
+        register_all_dialects(&registry);
+        registry
+    });
+    context.load_all_available_dialects();
+    register_all_passes();
+    register_all_llvm_translations(&context);
+    context
+}

--- a/crates/concrete_codegen_mlir/src/context.rs
+++ b/crates/concrete_codegen_mlir/src/context.rs
@@ -29,8 +29,6 @@ impl Context {
         Self { melior_context }
     }
 
-    /// Compiles an Austral program into MLIR and then lowers to LLVM.
-    /// Returns the corresponding Module struct.
     pub fn compile(
         &self,
         session: &Session,
@@ -40,10 +38,6 @@ impl Context {
         let location = Location::new(&self.melior_context, &file_path, 0, 0);
 
         let mut melior_module = MeliorModule::new(location);
-
-        if !session.library {
-            super::codegen::compile_start(&self.melior_context, &melior_module, "main");
-        }
 
         super::codegen::compile_program(&self.melior_context, &melior_module, program)?;
 

--- a/crates/concrete_codegen_mlir/src/error.rs
+++ b/crates/concrete_codegen_mlir/src/error.rs
@@ -1,0 +1,13 @@
+use std::error::Error;
+
+// TODO: Add implementation.
+#[derive(Debug, Clone, Copy)]
+pub struct CompilerError;
+
+impl std::fmt::Display for CompilerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("compiler error")
+    }
+}
+
+impl Error for CompilerError {}

--- a/crates/concrete_codegen_mlir/src/lib.rs
+++ b/crates/concrete_codegen_mlir/src/lib.rs
@@ -1,1 +1,179 @@
+use std::{
+    error::Error,
+    ffi::{CStr, CString},
+    fmt::Display,
+    mem::MaybeUninit,
+    path::PathBuf,
+    ptr::{addr_of_mut, null_mut},
+    sync::OnceLock,
+};
 
+use concrete_ast::Program;
+use concrete_session::{config::OptLevel, Session};
+use context::Context;
+use llvm_sys::{
+    core::{LLVMContextCreate, LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule},
+    prelude::{LLVMContextRef, LLVMModuleRef},
+    target::{
+        LLVM_InitializeAllAsmPrinters, LLVM_InitializeAllTargetInfos, LLVM_InitializeAllTargetMCs,
+        LLVM_InitializeAllTargets,
+    },
+    target_machine::{
+        LLVMCodeGenFileType, LLVMCodeGenOptLevel, LLVMCodeModel, LLVMCreateTargetMachine,
+        LLVMDisposeTargetMachine, LLVMGetDefaultTargetTriple, LLVMGetHostCPUFeatures,
+        LLVMGetHostCPUName, LLVMGetTargetFromTriple, LLVMRelocMode, LLVMTargetMachineEmitToFile,
+        LLVMTargetRef,
+    },
+};
+use module::MLIRModule;
+
+mod codegen;
+mod context;
+mod error;
+pub mod linker;
+mod module;
+mod pass_manager;
+
+/// Returns the object file path.
+pub fn compile(session: &Session, program: &Program) -> Result<PathBuf, Box<dyn Error>> {
+    let context = Context::new();
+    let mlir_module = context.compile(session, program)?;
+
+    let object_path = compile_to_object(session, &mlir_module)?;
+
+    Ok(object_path)
+}
+
+extern "C" {
+    /// Translate operation that satisfies LLVM dialect module requirements into an LLVM IR module living in the given context.
+    /// This translates operations from any dilalect that has a registered implementation of LLVMTranslationDialectInterface.
+    fn mlirTranslateModuleToLLVMIR(
+        module_operation_ptr: mlir_sys::MlirOperation,
+        llvm_context: LLVMContextRef,
+    ) -> LLVMModuleRef;
+}
+
+#[derive(Debug, Clone)]
+pub struct LLVMCompileError(String);
+
+impl std::error::Error for LLVMCompileError {}
+
+impl Display for LLVMCompileError {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Converts a module to an object.
+/// The object will be written to the specified target path.
+/// TODO: error handling
+///
+/// Returns the path to the object.
+pub fn compile_to_object(
+    session: &Session,
+    module: &MLIRModule<'_>,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    tracing::debug!("Compiling to object file");
+    if !session.target_dir.exists() {
+        std::fs::create_dir_all(&session.target_dir)?;
+    }
+
+    let target_file = session
+        .file_path
+        .clone()
+        .file_stem()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let target_file = PathBuf::from(target_file).with_extension("o");
+    tracing::debug!("Target file: {:?}", target_file);
+
+    let target_path = session.target_dir.join(target_file);
+
+    // TODO: Rework so you can specify target and host features, etc.
+    // Right now it compiles for the native cpu feature set and arch.
+    static INITIALIZED: OnceLock<()> = OnceLock::new();
+
+    INITIALIZED.get_or_init(|| unsafe {
+        LLVM_InitializeAllTargets();
+        LLVM_InitializeAllTargetInfos();
+        LLVM_InitializeAllTargetMCs();
+        LLVM_InitializeAllAsmPrinters();
+        tracing::debug!("initialized llvm targets");
+    });
+
+    unsafe {
+        let llvm_context = LLVMContextCreate();
+
+        let op = module.melior_module.as_operation().to_raw();
+
+        let llvm_module = mlirTranslateModuleToLLVMIR(op, llvm_context);
+
+        let mut null = null_mut();
+        let mut error_buffer = addr_of_mut!(null);
+
+        let target_triple = LLVMGetDefaultTargetTriple();
+        let target_cpu = LLVMGetHostCPUName();
+        let target_cpu_features = LLVMGetHostCPUFeatures();
+
+        let mut target: MaybeUninit<LLVMTargetRef> = MaybeUninit::uninit();
+
+        if LLVMGetTargetFromTriple(target_triple, target.as_mut_ptr(), error_buffer) != 0 {
+            let error = CStr::from_ptr(*error_buffer);
+            let err = error.to_string_lossy().to_string();
+            LLVMDisposeMessage(*error_buffer);
+            Err(LLVMCompileError(err))?;
+        } else if !(*error_buffer).is_null() {
+            LLVMDisposeMessage(*error_buffer);
+            error_buffer = addr_of_mut!(null);
+        }
+
+        let target = target.assume_init();
+
+        let machine = LLVMCreateTargetMachine(
+            target,
+            target_triple.cast(),
+            target_cpu.cast(),
+            target_cpu_features.cast(),
+            match session.optlevel {
+                OptLevel::None => LLVMCodeGenOptLevel::LLVMCodeGenLevelNone,
+                OptLevel::Less => LLVMCodeGenOptLevel::LLVMCodeGenLevelLess,
+                OptLevel::Default => LLVMCodeGenOptLevel::LLVMCodeGenLevelDefault,
+                OptLevel::Aggressive => LLVMCodeGenOptLevel::LLVMCodeGenLevelAggressive,
+            },
+            if session.library {
+                LLVMRelocMode::LLVMRelocDynamicNoPic
+            } else {
+                LLVMRelocMode::LLVMRelocDefault
+            },
+            LLVMCodeModel::LLVMCodeModelDefault,
+        );
+
+        let filename = CString::new(target_path.as_os_str().as_encoded_bytes()).unwrap();
+        tracing::debug!("filename to llvm: {:?}", filename);
+        let ok = LLVMTargetMachineEmitToFile(
+            machine,
+            llvm_module,
+            filename.as_ptr().cast_mut(),
+            LLVMCodeGenFileType::LLVMObjectFile, // object (binary) or assembly (textual)
+            error_buffer,
+        );
+
+        if ok != 0 {
+            let error = CStr::from_ptr(*error_buffer);
+            let err = error.to_string_lossy().to_string();
+            tracing::error!("error emitting to file: {:?}", err);
+            LLVMDisposeMessage(*error_buffer);
+            Err(LLVMCompileError(err))?;
+        } else if !(*error_buffer).is_null() {
+            LLVMDisposeMessage(*error_buffer);
+        }
+
+        LLVMDisposeTargetMachine(machine);
+        LLVMDisposeModule(llvm_module);
+        LLVMContextDispose(llvm_context);
+
+        Ok(target_path)
+    }
+}

--- a/crates/concrete_codegen_mlir/src/linker.rs
+++ b/crates/concrete_codegen_mlir/src/linker.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+
+use tracing::instrument;
+
+#[instrument(level = "debug")]
+pub fn link_shared_lib(input_path: &Path, output_filename: &Path) -> Result<(), std::io::Error> {
+    let args: &[&str] = {
+        #[cfg(target_os = "macos")]
+        {
+            &[
+                "-demangle",
+                "-no_deduplicate",
+                "-dynamic",
+                "-dylib",
+                "-L/usr/local/lib",
+                "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
+                &input_path.display().to_string(),
+                "-o",
+                &output_filename.display().to_string(),
+                "-lSystem",
+            ]
+        }
+        #[cfg(target_os = "linux")]
+        {
+            &[
+                "--hash-style=gnu",
+                "--eh-frame-hdr",
+                "-shared",
+                "-o",
+                &output_filename.display().to_string(),
+                "-L/lib/../lib64",
+                "-L/usr/lib/../lib64",
+                "-lc",
+                &input_path.display().to_string(),
+            ]
+        }
+        #[cfg(target_os = "windows")]
+        {
+            unimplemented!()
+        }
+    };
+
+    let mut linker = std::process::Command::new("ld");
+    let proc = linker.args(args.iter()).spawn()?;
+    proc.wait_with_output()?;
+    Ok(())
+}
+
+#[instrument(level = "debug")]
+pub fn link_binary(input_path: &Path, output_filename: &Path) -> Result<(), std::io::Error> {
+    let args: &[&str] = {
+        #[cfg(target_os = "macos")]
+        {
+            &[
+                "-L/usr/local/lib",
+                "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib",
+                &input_path.display().to_string(),
+                "-o",
+                &output_filename.display().to_string(),
+                "-lSystem",
+            ]
+        }
+        #[cfg(target_os = "linux")]
+        {
+            &[
+                "--hash-style=gnu",
+                "--eh-frame-hdr",
+                "-o",
+                &output_filename.display().to_string(),
+                "-L/lib/../lib64",
+                "-L/usr/lib/../lib64",
+                "-lc",
+                &input_path.display().to_string(),
+            ]
+        }
+        #[cfg(target_os = "windows")]
+        {
+            unimplemented!()
+        }
+    };
+
+    let mut linker = std::process::Command::new("ld");
+    let proc = linker.args(args.iter()).spawn()?;
+    proc.wait_with_output()?;
+    Ok(())
+}

--- a/crates/concrete_codegen_mlir/src/linker.rs
+++ b/crates/concrete_codegen_mlir/src/linker.rs
@@ -63,12 +63,15 @@ pub fn link_binary(input_path: &Path, output_filename: &Path) -> Result<(), std:
         #[cfg(target_os = "linux")]
         {
             &[
-                "--hash-style=gnu",
+                "-pie",
                 "--eh-frame-hdr",
+                "--dynamic-linker",
+                "/lib64/ld-linux-x86-64.so.2",
+                "-melf_x86_64",
                 "-o",
                 &output_filename.display().to_string(),
-                "-L/lib/../lib64",
-                "-L/usr/lib/../lib64",
+                "-L/lib64",
+                "-L/usr/lib64",
                 "-lc",
                 &input_path.display().to_string(),
             ]

--- a/crates/concrete_codegen_mlir/src/module.rs
+++ b/crates/concrete_codegen_mlir/src/module.rs
@@ -1,0 +1,30 @@
+use melior::ir::Module as MeliorModule;
+use std::fmt::Debug;
+
+/// A MLIR module in the context of the Concrete compiler.
+pub struct MLIRModule<'m> {
+    pub(crate) melior_module: MeliorModule<'m>,
+}
+
+impl<'m> MLIRModule<'m> {
+    pub fn new(module: MeliorModule<'m>) -> Self {
+        Self {
+            melior_module: module,
+        }
+    }
+
+    pub fn module(&self) -> &MeliorModule {
+        &self.melior_module
+    }
+
+    // TODO: uncomment this when we have a proper Program (we should get it from the DB).
+    // pub fn program_registry(&self) -> &ProgramRegistry<CoreType, CoreLibfunc> {
+    //     &self.registry
+    // }
+}
+
+impl Debug for MLIRModule<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.melior_module.as_operation().to_string())
+    }
+}

--- a/crates/concrete_codegen_mlir/src/pass_manager.rs
+++ b/crates/concrete_codegen_mlir/src/pass_manager.rs
@@ -1,0 +1,19 @@
+use melior::{
+    ir::Module as MeliorModule,
+    pass::{self, PassManager},
+    Context, Error,
+};
+
+pub fn run_pass_manager(context: &Context, module: &mut MeliorModule) -> Result<(), Error> {
+    let pass_manager = PassManager::new(context);
+    pass_manager.enable_verifier(true);
+    pass_manager.add_pass(pass::transform::create_canonicalizer());
+    pass_manager.add_pass(pass::conversion::create_scf_to_control_flow());
+    pass_manager.add_pass(pass::conversion::create_arith_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_control_flow_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_func_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_index_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_finalize_mem_ref_to_llvm());
+    pass_manager.add_pass(pass::conversion::create_reconcile_unrealized_casts());
+    pass_manager.run(module)
+}

--- a/crates/concrete_codegen_mlir/src/wrappers.cpp
+++ b/crates/concrete_codegen_mlir/src/wrappers.cpp
@@ -1,0 +1,23 @@
+#include <llvm-c/Support.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <mlir/CAPI/IR.h>
+#include <mlir/CAPI/Support.h>
+#include <mlir/CAPI/Wrap.h>
+#include <mlir/Dialect/LLVMIR/LLVMTypes.h>
+#include <mlir/IR/Types.h>
+#include <mlir/Target/LLVMIR/ModuleTranslation.h>
+
+extern "C" LLVMModuleRef mlirTranslateModuleToLLVMIR(MlirOperation module,
+                                          LLVMContextRef context) {
+  mlir::Operation *moduleOp = unwrap(module);
+
+  llvm::LLVMContext *ctx = llvm::unwrap(context);
+
+  std::unique_ptr<llvm::Module> llvmModule = mlir::translateModuleToLLVMIR(
+      moduleOp, *ctx);
+
+  LLVMModuleRef moduleRef = llvm::wrap(llvmModule.release());
+
+  return moduleRef;
+}

--- a/crates/concrete_driver/Cargo.toml
+++ b/crates/concrete_driver/Cargo.toml
@@ -6,3 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.13", features = ["derive"] }
+tracing.workspace = true
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+concrete_ast = { path = "../concrete_ast"}
+concrete_parser = { path = "../concrete_parser"}
+concrete_session = { path = "../concrete_session"}
+concrete_codegen_mlir = { path = "../concrete_codegen_mlir"}

--- a/crates/concrete_driver/README.md
+++ b/crates/concrete_driver/README.md
@@ -1,0 +1,3 @@
+# Concrete Driver
+
+The driver crate is effectively the "main" function for the Concrete compiler. It orchestrates the compilation process and "knits together" the code from the other crates within concrete.

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -37,7 +37,11 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     // todo: find a better name, "target" would clash with rust if running in the source tree.
     let target_dir = cwd.join("build_artifacts/");
     let output_file = target_dir.join(PathBuf::from(args.input.file_name().unwrap()));
-    tracing::debug!("Output file: {:?}", output_file);
+    let output_file = if args.library {
+        output_file.with_extension("so")
+    } else {
+        output_file.with_extension("")
+    };
 
     let session = Session {
         file_path: args.input,

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -1,1 +1,73 @@
+use std::{error::Error, path::PathBuf, time::Instant};
 
+use clap::Parser;
+use concrete_codegen_mlir::linker::{link_binary, link_shared_lib};
+use concrete_session::{
+    config::{DebugInfo, OptLevel},
+    Session,
+};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct CompilerArgs {
+    /// The input file.
+    input: PathBuf,
+
+    /// Build for release with all optimizations.
+    #[arg(short, long, default_value_t = false)]
+    release: bool,
+
+    /// Build as a library.
+    #[arg(short, long, default_value_t = false)]
+    library: bool,
+}
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    let start_time = Instant::now();
+
+    tracing_subscriber::fmt::init();
+
+    let args = CompilerArgs::parse();
+
+    let source = std::fs::read_to_string(args.input.clone())?;
+    tracing::debug!("source code:\n{}", source);
+    let program = concrete_parser::parse_ast(&source);
+
+    let cwd = std::env::current_dir()?;
+    // todo: find a better name, "target" would clash with rust if running in the source tree.
+    let target_dir = cwd.join("build_artifacts/");
+    let output_file = target_dir.join(PathBuf::from(args.input.file_name().unwrap()));
+    tracing::debug!("Output file: {:?}", output_file);
+
+    let session = Session {
+        file_path: args.input,
+        debug_info: if args.release {
+            DebugInfo::None
+        } else {
+            DebugInfo::Full
+        },
+        optlevel: if args.release {
+            OptLevel::Aggressive
+        } else {
+            OptLevel::None
+        },
+        source,
+        library: args.library,
+        target_dir,
+        output_file,
+    };
+    tracing::debug!("Compiling with session: {:#?}", session);
+
+    let object_path = concrete_codegen_mlir::compile(&session, &program)?;
+
+    if session.library {
+        link_shared_lib(&object_path, &session.output_file.with_extension("so"))?;
+    } else {
+        link_binary(&object_path, &session.output_file.with_extension(""))?;
+    }
+
+    let elapsed = start_time.elapsed();
+    tracing::debug!("Done in {:?}", elapsed);
+
+    Ok(())
+}

--- a/crates/concrete_parser/Cargo.toml
+++ b/crates/concrete_parser/Cargo.toml
@@ -10,9 +10,7 @@ lalrpop-util = { version = "0.20.0", features = ["unicode"] }
 logos = "0.13.0"
 tracing.workspace = true
 concrete_ast = { path = "../concrete_ast"}
+owo-colors = "4.0.0"
 
 [build-dependencies]
 lalrpop = "0.20.0"
-
-[dev-dependencies]
-owo-colors = "4.0.0"

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -138,19 +138,23 @@ pub(crate) GenericParams: Vec<ast::common::GenericParam> = {
 
 // Module list
 
-pub Program: Vec<ast::modules::ModuleBase> = {
-  <ModuleBase> => vec![<>],
-  <mut s:Program> <n:ModuleBase> => {
-      s.push(n);
+pub Program: ast::Program = {
+  <Module> => {
+    ast::Program {
+      modules: vec![<>],
+    }
+  },
+  <mut s:Program> <n:Module> => {
+      s.modules.push(n);
       s
   },
 }
 
 // Modules
 
-pub(crate) ModuleBase: ast::modules::ModuleBase = {
+pub(crate) Module: ast::modules::Module = {
   "mod" <name:Ident> "{" <contents:ModuleItems> "}" => {
-    ast::modules::ModuleBase {
+    ast::modules::Module {
       doc_string: None,
       imports: vec![], // todo: add imports
       name,

--- a/crates/concrete_session/Cargo.toml
+++ b/crates/concrete_session/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
-name = "concrete"
+name = "concrete_session"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concrete_driver = { path = "../concrete_driver"}

--- a/crates/concrete_session/README.md
+++ b/crates/concrete_session/README.md
@@ -1,0 +1,3 @@
+# Concrete Session
+
+Represents the data associated with a compilation session for a single package.

--- a/crates/concrete_session/src/config.rs
+++ b/crates/concrete_session/src/config.rs
@@ -1,0 +1,13 @@
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub enum OptLevel {
+    None,       // -O0
+    Less,       // -O1
+    Default,    // -O2
+    Aggressive, // -O3
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub enum DebugInfo {
+    None,
+    Full,
+}

--- a/crates/concrete_session/src/lib.rs
+++ b/crates/concrete_session/src/lib.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use config::{DebugInfo, OptLevel};
+
+pub mod config;
+
+#[derive(Debug, Clone)]
+pub struct Session {
+    pub file_path: PathBuf,
+    pub debug_info: DebugInfo,
+    pub optlevel: OptLevel,
+    pub source: String, // for debugging locations
+    /// True if it should be compiled as a library false for binary.
+    pub library: bool,
+    /// The directory where to store artifacts and intermediate files such as object files.
+    pub target_dir: PathBuf,
+    pub output_file: PathBuf,
+    // todo: include target, host, etc
+}
+
+impl Session {
+    pub fn get_line_and_column(&self, offset: usize) -> (usize, usize) {
+        let sl = &self.source[0..offset];
+        let line_count = sl.lines().count();
+        let column = sl.rfind('\n').unwrap_or(0);
+        (line_count, column)
+    }
+}

--- a/examples/fib.con
+++ b/examples/fib.con
@@ -1,0 +1,8 @@
+mod FactorialModule {
+    pub fn factorial(x: u64) -> u64  {
+        return match x {
+            0 -> return 1,
+            n -> return n * factorial(n-1),
+        };
+    }
+}


### PR DESCRIPTION
- Added concrete_session, which holds information about the current compile unit and used by the driver and codegen.
- Added the initial compiler driver, which drives the compilation process using the parser, mlir codegen and linker to produce a binary.

The cli interface or the driver is by no means anything ready but it's enough to be able to compile programs and help the development further.

Like rust, we use a folder to store intermediate files and artifacts (like object files) (like a `target/`), for now i called it `build_artifacts`.

`cargo r -- --library examples/fib.con` produces right now an empty shared library (since we dont have codegen implemented yet)

outputs this:

```
2024-01-08T15:11:42.387329Z DEBUG concrete_driver: source code:
mod FactorialModule {
    pub fn factorial(x: u64) -> u64  {
        return match x {
            0 -> return 1,
            n -> return n * factorial(n-1),
        };
    }
}

2024-01-08T15:11:42.387409Z DEBUG concrete_driver: Output file: "/snip/concrete/build_artifacts/fib.con"
2024-01-08T15:11:42.387414Z DEBUG concrete_driver: Compiling with session: Session {
    file_path: "examples/fib.con",
    debug_info: Full,
    optlevel: None,
    source: "mod FactorialModule {\n    pub fn factorial(x: u64) -> u64  {\n        return match x {\n            0 -> return 1,\n            n -> return n * factorial(n-1),\n        };\n    }\n}\n",
    library: true,
    target_dir: "/snip/concrete/build_artifacts/",
    output_file: "/snip/concrete/build_artifacts/fib.so",
}
2024-01-08T15:11:42.390431Z DEBUG concrete_codegen_mlir: Compiling to object file
2024-01-08T15:11:42.390443Z DEBUG concrete_codegen_mlir: Target file: "fib.o"
2024-01-08T15:11:42.390501Z DEBUG concrete_codegen_mlir: initialized llvm targets
2024-01-08T15:11:42.390632Z DEBUG concrete_codegen_mlir: filename to llvm: "/snip/concrete/build_artifacts/fib.o"
2024-01-08T15:11:42.397798Z DEBUG concrete_driver: Done in 11.054603ms
```
