### PR TITLE
Add `nix-shell` support.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,8 @@
 
 let
   pinnedPkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz";
-    sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+    url = "https://github.com/NixOS/nixpkgs/archive/23.11.tar.gz";
+    sha256 = "1ndiv385w1qyb3b18vw13991fzb9wg4cl21wglk89grsfsnra41k";
   };
   pkgs = import pinnedPkgs {};
 in
@@ -12,5 +12,10 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     pkgs.cargo
     pkgs.rustc
+
+    pkgs.iconv
+    pkgs.llvm_17
+    pkgs.ncurses
+    pkgs.zlib
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+let
+  pinnedPkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz";
+    sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+  };
+  pkgs = import pinnedPkgs {};
+in
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    pkgs.cargo
+    pkgs.rustc
+  ];
+}


### PR DESCRIPTION
Currently broken because nixpkgs doesn't have `llvm_17`.