### PR TITLE
Add git attribute for syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.con linguist-language=Rust


### PR DESCRIPTION
Since Concrete looks similar to Rust, using the same syntax highlighter for now should do wonders, especially for the GitHub code viewer.

I have added the necessary setting under `.gitattributes`, you can see it in action here: https://github.com/erhant/concrete/blob/erhant/gitattr/examples/simple.con

Note that this will also make `*.con` files count as Rust files for the language statistics, but I think that is okay for now. This attribute should be removed when Concrete highlighter is created & merged to Linguist.