### PR TITLE
Add imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "cc",
  "concrete_ast",
  "concrete_session",
+ "itertools 0.12.0",
  "llvm-sys",
  "melior",
  "mlir-sys",

--- a/crates/concrete_ast/src/constants.rs
+++ b/crates/concrete_ast/src/constants.rs
@@ -8,6 +8,7 @@ use crate::{
 pub struct ConstantDecl {
     pub doc_string: Option<DocString>,
     pub name: Ident,
+    pub is_pub: bool,
     pub r#type: TypeSpec,
 }
 

--- a/crates/concrete_ast/src/modules.rs
+++ b/crates/concrete_ast/src/modules.rs
@@ -19,6 +19,7 @@ pub struct Module {
 pub enum ModuleDefItem {
     Constant(ConstantDef),
     Function(FunctionDef),
-    Record(StructDecl),
+    Struct(StructDecl),
     Type(TypeDecl),
+    Module(Module),
 }

--- a/crates/concrete_ast/src/structs.rs
+++ b/crates/concrete_ast/src/structs.rs
@@ -5,15 +5,15 @@ use crate::{
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StructDecl {
-    doc_string: Option<DocString>,
-    name: Ident,
-    type_params: Vec<GenericParam>,
-    fields: Vec<Field>,
+    pub doc_string: Option<DocString>,
+    pub name: Ident,
+    pub type_params: Vec<GenericParam>,
+    pub fields: Vec<Field>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Field {
-    doc_string: Option<DocString>,
-    name: Ident,
-    r#type: TypeSpec,
+    pub doc_string: Option<DocString>,
+    pub name: Ident,
+    pub r#type: TypeSpec,
 }

--- a/crates/concrete_ast/src/types.rs
+++ b/crates/concrete_ast/src/types.rs
@@ -1,4 +1,4 @@
-use crate::common::{DocString, Ident};
+use crate::common::{DocString, Ident, Span};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum TypeSpec {
@@ -8,6 +8,7 @@ pub enum TypeSpec {
     Generic {
         name: Ident,
         type_params: Vec<TypeSpec>,
+        span: Span,
     },
 }
 
@@ -15,4 +16,5 @@ pub enum TypeSpec {
 pub struct TypeDecl {
     pub doc_string: Option<DocString>,
     pub name: Ident,
+    pub value: TypeSpec,
 }

--- a/crates/concrete_codegen_mlir/Cargo.toml
+++ b/crates/concrete_codegen_mlir/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bumpalo = { version = "3.14.0", features = ["std"] }
 concrete_ast = { path = "../concrete_ast"}
 concrete_session = { path = "../concrete_session"}
+itertools = "0.12.0"
 llvm-sys = "170.0.1"
 melior = { version = "0.15.0", features = ["ods-dialects"] }
 mlir-sys = "0.2.1"

--- a/crates/concrete_codegen_mlir/src/ast_helper.rs
+++ b/crates/concrete_codegen_mlir/src/ast_helper.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+
+use concrete_ast::{
+    common::Ident,
+    constants::ConstantDef,
+    functions::FunctionDef,
+    modules::{Module, ModuleDefItem},
+    structs::StructDecl,
+    types::TypeDecl,
+    Program,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModuleInfo<'p> {
+    pub name: String,
+    pub functions: HashMap<String, &'p FunctionDef>,
+    pub constants: HashMap<String, &'p ConstantDef>,
+    pub structs: HashMap<String, &'p StructDecl>,
+    pub types: HashMap<String, &'p TypeDecl>,
+    pub modules: HashMap<String, ModuleInfo<'p>>,
+}
+
+impl<'p> ModuleInfo<'p> {
+    pub fn get_module_from_import(&self, import: &[Ident]) -> Option<&ModuleInfo<'p>> {
+        let next = import.first()?;
+        let module = self.modules.get(&next.name)?;
+
+        if import.len() > 1 {
+            module.get_module_from_import(&import[1..])
+        } else {
+            Some(module)
+        }
+    }
+
+    /// Returns the symbol name from a local name.
+    pub fn get_symbol_name(&self, local_name: &str) -> String {
+        if local_name == "main" {
+            return local_name.to_string();
+        }
+
+        let mut result = self.name.clone();
+
+        result.push_str("::");
+        result.push_str(local_name);
+
+        result
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AstHelper<'p> {
+    pub root: &'p Program,
+    pub modules: HashMap<String, ModuleInfo<'p>>,
+}
+
+impl<'p> AstHelper<'p> {
+    pub fn new(root: &'p Program) -> Self {
+        let mut modules = HashMap::default();
+
+        for module in &root.modules {
+            modules.insert(
+                module.name.name.clone(),
+                Self::create_module_info(module, None),
+            );
+        }
+
+        Self { root, modules }
+    }
+
+    pub fn get_module_from_import(&self, import: &[Ident]) -> Option<&ModuleInfo<'p>> {
+        let next = import.first()?;
+        let module = self.modules.get(&next.name)?;
+
+        if import.len() > 1 {
+            module.get_module_from_import(&import[1..])
+        } else {
+            Some(module)
+        }
+    }
+
+    fn create_module_info(module: &Module, parent_name: Option<String>) -> ModuleInfo<'_> {
+        let mut functions = HashMap::default();
+        let mut constants = HashMap::default();
+        let mut structs = HashMap::default();
+        let mut types = HashMap::default();
+        let mut child_modules = HashMap::default();
+        let mut name = parent_name.clone().unwrap_or_default();
+
+        if name.is_empty() {
+            name = module.name.name.clone();
+        } else {
+            name.push_str(&format!("::{}", module.name.name));
+        }
+
+        for stmt in &module.contents {
+            match stmt {
+                ModuleDefItem::Constant(info) => {
+                    constants.insert(info.decl.name.name.clone(), info);
+                }
+                ModuleDefItem::Function(info) => {
+                    functions.insert(info.decl.name.name.clone(), info);
+                }
+                ModuleDefItem::Struct(info) => {
+                    structs.insert(info.name.name.clone(), info);
+                }
+                ModuleDefItem::Type(info) => {
+                    types.insert(info.name.name.clone(), info);
+                }
+                ModuleDefItem::Module(info) => {
+                    child_modules.insert(
+                        info.name.name.clone(),
+                        Self::create_module_info(info, Some(name.clone())),
+                    );
+                }
+            }
+        }
+
+        ModuleInfo {
+            name,
+            functions,
+            structs,
+            constants,
+            types,
+            modules: child_modules,
+        }
+    }
+}

--- a/crates/concrete_codegen_mlir/src/lib.rs
+++ b/crates/concrete_codegen_mlir/src/lib.rs
@@ -29,6 +29,7 @@ use llvm_sys::{
 };
 use module::MLIRModule;
 
+mod ast_helper;
 mod codegen;
 mod context;
 mod error;

--- a/crates/concrete_driver/tests/programs.rs
+++ b/crates/concrete_driver/tests/programs.rs
@@ -105,3 +105,28 @@ fn test_simple_add() {
     let code = output.status.code().unwrap();
     assert_eq!(code, 8);
 }
+
+#[test]
+fn test_import() {
+    let source = r#"
+        mod Simple {
+            import Other.{hello};
+
+            fn main() -> i64 {
+                return hello(4);
+            }
+        }
+
+        mod Other {
+            pub fn hello(x: i64) -> i64 {
+                return x * 2;
+            }
+        }
+    "#;
+
+    let result = compile_program(source, "import", false).expect("failed to compile");
+
+    let output = run_program(&result.binary_file).expect("failed to run");
+    let code = output.status.code().unwrap();
+    assert_eq!(code, 8);
+}

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -1,7 +1,9 @@
 use crate::tokens::Token;
 use crate::lexer::LexicalError;
 use concrete_ast as ast;
+use ast::common::Span;
 use std::str::FromStr;
+
 
 grammar;
 
@@ -133,9 +135,10 @@ pub(crate) TypeSpec: ast::types::TypeSpec = {
   <name:Ident> => ast::types::TypeSpec::Simple {
     name
   },
-  <name:Ident> "<" <type_params:Comma<TypeSpec>> ">" => ast::types::TypeSpec::Generic {
+  <lo:@L> <name:Ident> "<" <type_params:Comma<TypeSpec>> ">" <hi:@R> => ast::types::TypeSpec::Generic {
     name,
-    type_params
+    type_params,
+    span: Span::new(lo, hi),
   }
 }
 
@@ -214,17 +217,21 @@ pub(crate) ModuleDefItem: ast::modules::ModuleDefItem = {
   },
   <FunctionDef> => {
     ast::modules::ModuleDefItem::Function(<>)
-  }
+  },
+  <Module> => {
+    ast::modules::ModuleDefItem::Module(<>)
+  },
 }
 
 // Constants
 
 pub(crate) ConstantDef: ast::constants::ConstantDef = {
-  "const" <name:Ident> ":" <type_spec:TypeSpec> "=" <exp:Expression> => {
+  <is_pub:"pub"?> "const" <name:Ident> ":" <type_spec:TypeSpec> "=" <exp:Expression> => {
     ast::constants::ConstantDef {
       decl: ast::constants::ConstantDecl {
         doc_string: None,
         name,
+        is_pub: is_pub.is_some(),
         r#type: type_spec
       },
       value: exp,

--- a/examples/import.con
+++ b/examples/import.con
@@ -1,0 +1,20 @@
+mod Simple {
+    import Other.{hello1};
+    import Other.Deep.{hello2};
+
+    fn main() -> i64 {
+        return hello1(2) + hello2(2);
+    }
+}
+
+mod Other {
+    pub fn hello1(x: i64) -> i64 {
+        return x * 2;
+    }
+
+    mod Deep {
+        pub fn hello2(x: i64) -> i64 {
+            return x * 4;
+        }
+    }
+}


### PR DESCRIPTION
Depends on #77 

Current limitations (todo):
- No support for absolute paths when calling a function
- Import symbol renaming

See: https://github.com/lambdaclass/concrete/issues/73

The following compiles:
```
mod Simple {
    import Other.{hello1};
    import Other.Deep.{hello2};

    fn main() -> i64 {
        return hello1(2) + hello2(2);
    }
}

mod Other {
    pub fn hello1(x: i64) -> i64 {
        return x * 2;
    }

    mod Deep {
        pub fn hello2(x: i64) -> i64 {
            return x * 4;
        }
    }
}
```
