### PR TITLE
[Codegen / Parsing] Add basic codegen for references, add parsing for arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "melior"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758bbd4448db9e994578ab48a6da5210512378f70ac1632cc8c2ae0fbd6c21b5"
+checksum = "878012ddccd6fdd099a4d98cebdecbaed9bc5eb325d0778ab9d4f4a52c67c18e"
 dependencies = [
  "dashmap",
  "melior-macro",

--- a/crates/concrete_ast/src/expressions.rs
+++ b/crates/concrete_ast/src/expressions.rs
@@ -2,7 +2,7 @@ use crate::{common::Ident, statements::Statement, types::TypeSpec};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expression {
-    Simple(SimpleExpr),
+    Value(ValueExpr),
     FnCall(FnCallOp),
     Match(MatchExpr),
     If(IfExpr),
@@ -10,15 +10,15 @@ pub enum Expression {
     BinaryOp(Box<Self>, BinaryOp, Box<Self>),
 }
 
-// needed for match variants and array accesses
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum SimpleExpr {
+pub enum ValueExpr {
     ConstBool(bool),
     ConstChar(char),
     ConstInt(u64),
     ConstFloat(()),
     ConstStr(String),
     Path(PathOp),
+    Deref(PathOp),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -83,14 +83,14 @@ pub struct IfExpr {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MatchVariant {
-    pub case: SimpleExpr,
+    pub case: ValueExpr,
     pub block: Vec<Statement>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PathSegment {
     FieldAccess(Ident),
-    ArrayIndex(SimpleExpr),
+    ArrayIndex(ValueExpr),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/concrete_ast/src/expressions.rs
+++ b/crates/concrete_ast/src/expressions.rs
@@ -1,4 +1,8 @@
-use crate::{common::Ident, statements::Statement, types::TypeSpec};
+use crate::{
+    common::Ident,
+    statements::Statement,
+    types::{RefType, TypeSpec},
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expression {
@@ -19,6 +23,7 @@ pub enum ValueExpr {
     ConstStr(String),
     Path(PathOp),
     Deref(PathOp),
+    AsRef { path: PathOp, ref_type: RefType },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/concrete_ast/src/types.rs
+++ b/crates/concrete_ast/src/types.rs
@@ -1,15 +1,40 @@
 use crate::common::{DocString, Ident, Span};
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Copy)]
+pub enum RefType {
+    Borrow,
+    MutBorrow,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum TypeSpec {
     Simple {
         name: Ident,
+        is_ref: Option<RefType>,
+        span: Span,
     },
     Generic {
         name: Ident,
+        is_ref: Option<RefType>,
         type_params: Vec<TypeSpec>,
         span: Span,
     },
+    Array {
+        of_type: Box<Self>,
+        size: Option<u64>,
+        is_ref: Option<RefType>,
+        span: Span,
+    },
+}
+
+impl TypeSpec {
+    pub fn is_ref(&self) -> Option<RefType> {
+        match self {
+            TypeSpec::Simple { is_ref, .. } => *is_ref,
+            TypeSpec::Generic { is_ref, .. } => *is_ref,
+            TypeSpec::Array { is_ref, .. } => *is_ref,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/crates/concrete_codegen_mlir/Cargo.toml
+++ b/crates/concrete_codegen_mlir/Cargo.toml
@@ -11,7 +11,7 @@ concrete_ast = { path = "../concrete_ast"}
 concrete_session = { path = "../concrete_session"}
 itertools = "0.12.0"
 llvm-sys = "170.0.1"
-melior = { version = "0.15.0", features = ["ods-dialects"] }
+melior = { version = "0.15.2", features = ["ods-dialects"] }
 mlir-sys = "0.2.1"
 tracing.workspace = true
 

--- a/crates/concrete_codegen_mlir/src/codegen.rs
+++ b/crates/concrete_codegen_mlir/src/codegen.rs
@@ -898,7 +898,7 @@ fn compile_path_op<'ctx, 'parent: 'ctx>(
     let local = scope_ctx
         .locals
         .get(&path.first.name)
-        .expect("local not found")
+        .unwrap_or_else(|| panic!("local {} not found", path.first.name))
         .clone();
 
     let location = get_location(context, session, path.first.span.from);

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -23,6 +23,10 @@ pub struct CompilerArgs {
     /// Build as a library.
     #[arg(short, long, default_value_t = false)]
     library: bool,
+
+    /// Prints the ast.
+    #[arg(long, default_value_t = false)]
+    print_ast: bool,
 }
 
 pub fn main() -> Result<(), Box<dyn Error>> {
@@ -52,6 +56,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             std::process::exit(1);
         }
     };
+
+    if args.print_ast {
+        println!("{:#?}", program);
+    }
 
     let cwd = std::env::current_dir()?;
     // todo: find a better name, "target" would clash with rust if running in the source tree.

--- a/crates/concrete_driver/tests/programs.rs
+++ b/crates/concrete_driver/tests/programs.rs
@@ -130,3 +130,31 @@ fn test_import() {
     let code = output.status.code().unwrap();
     assert_eq!(code, 8);
 }
+
+#[test]
+fn test_reference() {
+    let source = r#"
+        mod Simple {
+            fn main(argc: i64) -> i64 {
+                let x: i64 = argc;
+                return references(x) + dereference(&x);
+            }
+
+            fn dereference(a: &i64) -> i64 {
+                return *a;
+            }
+
+            fn references(a: i64) -> i64 {
+                let x: i64 = a;
+                let y: &i64 = &x;
+                return *y;
+            }
+        }
+    "#;
+
+    let result = compile_program(source, "references", false).expect("failed to compile");
+
+    let output = run_program(&result.binary_file).expect("failed to run");
+    let code = output.status.code().unwrap();
+    assert_eq!(code, 2);
+}

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -66,7 +66,7 @@ extern {
     "!" => Token::OperatorNot,
     "~" => Token::OperatorBitwiseNot,
     "^" => Token::OperatorBitwiseXor,
-    "&" => Token::OperatorBitwiseAnd,
+    "&" => Token::Ampersand,
     "|" => Token::OperatorBitwiseOr,
   }
 }
@@ -131,13 +131,27 @@ pub(crate) Ident: ast::common::Ident = {
   }
 }
 
+pub(crate) RefType: ast::types::RefType = {
+  "&" => ast::types::RefType::Borrow,
+  "&" "mut" => ast::types::RefType::MutBorrow,
+}
+
 pub(crate) TypeSpec: ast::types::TypeSpec = {
-  <name:Ident> => ast::types::TypeSpec::Simple {
-    name
+  <lo:@L> <is_ref:RefType?> <name:Ident> <hi:@R> => ast::types::TypeSpec::Simple {
+    name,
+    is_ref,
+    span: Span::new(lo, hi),
   },
-  <lo:@L> <name:Ident> "<" <type_params:Comma<TypeSpec>> ">" <hi:@R> => ast::types::TypeSpec::Generic {
+  <lo:@L> <is_ref:RefType?> <name:Ident> "<" <type_params:Comma<TypeSpec>> ">" <hi:@R> => ast::types::TypeSpec::Generic {
     name,
     type_params,
+    is_ref,
+    span: Span::new(lo, hi),
+  },
+  <lo:@L> <is_ref:RefType?> "[" <of_type:TypeSpec> <size:(";" <"integer">)?> "]"<hi:@R> => ast::types::TypeSpec::Array {
+    of_type: Box::new(of_type),
+    size,
+    is_ref,
     span: Span::new(lo, hi),
   }
 }
@@ -272,7 +286,7 @@ pub(crate) FunctionDef: ast::functions::FunctionDef = {
 // Expressions
 
 pub(crate) Term: ast::expressions::Expression = {
-  <SimpleExpr> => ast::expressions::Expression::Simple(<>),
+  <ValueExpr> => ast::expressions::Expression::Value(<>),
   <FnCallOp> => ast::expressions::Expression::FnCall(<>),
   <MatchExpr> => ast::expressions::Expression::Match(<>),
   <IfExpr> => ast::expressions::Expression::If(<>),
@@ -339,13 +353,13 @@ pub UnaryOp: ast::expressions::UnaryOp = {
   "~" => ast::expressions::UnaryOp::BitwiseNot,
 }
 
-pub(crate) SimpleExpr: ast::expressions::SimpleExpr = {
-  <"integer"> => ast::expressions::SimpleExpr::ConstInt(<>),
-  <"boolean"> => ast::expressions::SimpleExpr::ConstBool(<>),
-  <"string"> => ast::expressions::SimpleExpr::ConstStr(<>),
-  <PathOp> => ast::expressions::SimpleExpr::Path(<>),
+pub(crate) ValueExpr: ast::expressions::ValueExpr = {
+  <"integer"> => ast::expressions::ValueExpr::ConstInt(<>),
+  <"boolean"> => ast::expressions::ValueExpr::ConstBool(<>),
+  <"string"> => ast::expressions::ValueExpr::ConstStr(<>),
+  <PathOp> => ast::expressions::ValueExpr::Path(<>),
+  "*" <PathOp> => ast::expressions::ValueExpr::Deref(<>),
 }
-
 
 pub(crate) IfExpr: ast::expressions::IfExpr = {
   "if" <value:Expression> "{" <contents:StatementList> "}"
@@ -369,14 +383,14 @@ pub(crate) MatchExpr: ast::expressions::MatchExpr = {
 
 pub(crate) MatchVariant: ast::expressions::MatchVariant = {
   // 0 -> 1
-  <case:SimpleExpr> "->" <stmt:Statement> => {
+  <case:ValueExpr> "->" <stmt:Statement> => {
     ast::expressions::MatchVariant {
       case,
       block: vec![stmt]
     }
   },
   // x -> { ... }
-  <case:SimpleExpr> "->" "{" <stmts:StatementList> "}" => {
+  <case:ValueExpr> "->" "{" <stmts:StatementList> "}" => {
     ast::expressions::MatchVariant {
       case,
       block: stmts
@@ -393,7 +407,7 @@ pub(crate) PathOp: ast::expressions::PathOp = {
 
 pub(crate) PathSegment: ast::expressions::PathSegment = {
   "." <Ident> => ast::expressions::PathSegment::FieldAccess(<>),
-  "[" <e:SimpleExpr> "]" => ast::expressions::PathSegment::ArrayIndex(e),
+  "[" <e:ValueExpr> "]" => ast::expressions::PathSegment::ArrayIndex(e),
 }
 
 pub PathSegments: Vec<ast::expressions::PathSegment> = {

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -359,6 +359,10 @@ pub(crate) ValueExpr: ast::expressions::ValueExpr = {
   <"string"> => ast::expressions::ValueExpr::ConstStr(<>),
   <PathOp> => ast::expressions::ValueExpr::Path(<>),
   "*" <PathOp> => ast::expressions::ValueExpr::Deref(<>),
+  <ref_type:RefType> <path:PathOp> => ast::expressions::ValueExpr::AsRef {
+    path,
+    ref_type
+  },
 }
 
 pub(crate) IfExpr: ast::expressions::IfExpr = {

--- a/crates/concrete_parser/src/tokens.rs
+++ b/crates/concrete_parser/src/tokens.rs
@@ -122,7 +122,7 @@ pub enum Token {
     #[token("^")]
     OperatorBitwiseXor,
     #[token("&")]
-    OperatorBitwiseAnd,
+    Ampersand,
     #[token("|")]
     OperatorBitwiseOr,
 }

--- a/examples/borrow.con
+++ b/examples/borrow.con
@@ -1,0 +1,17 @@
+mod Simple {
+    fn main(argc: i64) -> i64 {
+        return argc;
+    }
+
+    fn hello(a: &i64) -> i64 {
+        return *a;
+    }
+
+    fn hello2(a: [i64]) -> i64 {
+        return a[0];
+    }
+
+     fn hello3(a: [i64; 4]) -> i64 {
+        return a[0];
+    }
+}

--- a/examples/borrow.con
+++ b/examples/borrow.con
@@ -3,15 +3,7 @@ mod Simple {
         return argc;
     }
 
-    fn hello(a: &i64) -> i64 {
+    fn dereference(a: &i64) -> i64 {
         return *a;
-    }
-
-    fn hello2(a: [i64]) -> i64 {
-        return a[0];
-    }
-
-     fn hello3(a: [i64; 4]) -> i64 {
-        return a[0];
     }
 }

--- a/examples/borrow.con
+++ b/examples/borrow.con
@@ -1,9 +1,16 @@
 mod Simple {
     fn main(argc: i64) -> i64 {
-        return argc;
+        let x: i64 = argc;
+        return references(x) + dereference(&x);
     }
 
     fn dereference(a: &i64) -> i64 {
         return *a;
+    }
+
+    fn references(a: i64) -> i64 {
+        let x: i64 = a;
+        let y: &i64 = &x;
+        return *y;
     }
 }


### PR DESCRIPTION
Depends on #79 

- Adds basic codegen for references and dereferences
- Adds arrays to the ast and parser

The following program compiles and works:
```rust
mod Simple {
    fn main(argc: i64) -> i64 {
        let x: i64 = argc;
        return references(x) + dereference(&x);
    }

    fn dereference(a: &i64) -> i64 {
        return *a;
    }

    fn references(a: i64) -> i64 {
        let x: i64 = a;
        let y: &i64 = &x;
        return *y;
    }
}

```