### PR TITLE
Improve the concrete cli, project manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,10 @@ name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -386,6 +390,7 @@ dependencies = [
 name = "concrete_driver"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ariadne",
  "clap",
  "concrete_ast",
@@ -394,11 +399,16 @@ dependencies = [
  "concrete_ir",
  "concrete_parser",
  "concrete_session",
+ "git2",
+ "owo-colors",
  "salsa-2022",
+ "serde",
  "tempfile",
  "test-case",
+ "toml",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -746,6 +756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +773,21 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git2"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -809,6 +843,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +904,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +962,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +994,32 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1142,10 +1235,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parking_lot"
@@ -1181,6 +1298,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -1472,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1865,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,10 +1990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1845,6 +2041,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +2062,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2172,6 +2385,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xdg"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Make sure you have installed the dependencies:
 - git
 - Rust
 - LLVM 17 with MLIR enabled
+- libgit2
 
 If building LLVM from source, you'll need additional tools:
 - g++, clang++, or MSVC with versions listed on [LLVM's documentation](https://llvm.org/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library)

--- a/crates/concrete/src/main.rs
+++ b/crates/concrete/src/main.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    concrete_driver::main()
+    Ok(concrete_driver::main()?)
 }

--- a/crates/concrete_ast/src/lib.rs
+++ b/crates/concrete_ast/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use modules::Module;
 
 pub mod common;
@@ -12,5 +14,6 @@ pub mod types;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Program {
+    pub file_path: Option<PathBuf>,
     pub modules: Vec<Module>,
 }

--- a/crates/concrete_check/src/lib.rs
+++ b/crates/concrete_check/src/lib.rs
@@ -1,20 +1,23 @@
-use std::ops::Range;
+use std::{ops::Range, path::PathBuf};
 
 use ariadne::{ColorGenerator, Label, Report, ReportKind};
 use concrete_ir::lowering::errors::LoweringError;
-use concrete_session::Session;
 
 /// Creates a report from a lowering error.
 pub fn lowering_error_to_report(
     error: LoweringError,
-    session: &Session,
-) -> Report<(String, Range<usize>)> {
-    let path = session.file_path.display().to_string();
+    file_paths: &[PathBuf],
+) -> Report<'static, (String, Range<usize>)> {
     let mut colors = ColorGenerator::new();
     colors.next();
     match error {
-        LoweringError::ModuleNotFound { span, module } => {
+        LoweringError::ModuleNotFound {
+            span,
+            module,
+            program_id,
+        } => {
             let offset = span.from;
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), offset)
                 .with_code("ModuleNotFound")
                 .with_label(
@@ -25,65 +28,94 @@ pub fn lowering_error_to_report(
                 .with_message("Unresolved import.")
                 .finish()
         }
-        LoweringError::FunctionNotFound { span, function } => {
+        LoweringError::FunctionNotFound {
+            span,
+            function,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
-            .with_code("FunctionNotFound")
-            .with_label(
-                Label::new((path, span.into()))
-                    .with_message(format!("Function {function:?} not found."))
-                    .with_color(colors.next()),
-            )
-            .finish()
-        },
-        LoweringError::StructFieldNotFound { span, name } => {
+                .with_code("FunctionNotFound")
+                .with_label(
+                    Label::new((path, span.into()))
+                        .with_message(format!("Function {function:?} not found."))
+                        .with_color(colors.next()),
+                )
+                .finish()
+        }
+        LoweringError::StructFieldNotFound {
+            span,
+            name,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
-            .with_code("StructFieldNotFound")
-            .with_label(
-                Label::new((path, span.into()))
-                    .with_message(format!("Struct field {name:?} not found."))
-                    .with_color(colors.next()),
-            )
-            .finish()
-        },
-        LoweringError::ImportNotFound { import_span, module_span, symbol } => {
-                let offset = symbol.span.from;
-                Report::build(ReportKind::Error, path.clone(), offset)
-                    .with_code("ImportNotFound")
-                    .with_label(
-                        Label::new((path.clone(), module_span.into()))
-                            .with_message("In module this module."),
-                    )
-                    .with_label(
-                        Label::new((path.clone(), import_span.into()))
-                            .with_message("In this import statement"),
-                    )
-                    .with_label(
-                        Label::new((path, symbol.span.into()))
-                            .with_message(format!("Failed to find symbol {:?}", symbol.name))
-                            .with_color(colors.next()),
-                    )
-                    .with_message("Unresolved import.")
-                    .finish()
-        },
-        LoweringError::BorrowNotMutable { span, name, type_span } => {
-            let mut labels = vec![
-                Label::new((path.clone(), span.into()))
-            .with_message(format!("Can't mutate {name:?} because it's behind a immutable borrow"))
-            .with_color(colors.next())
-            ];
+                .with_code("StructFieldNotFound")
+                .with_label(
+                    Label::new((path, span.into()))
+                        .with_message(format!("Struct field {name:?} not found."))
+                        .with_color(colors.next()),
+                )
+                .finish()
+        }
+        LoweringError::ImportNotFound {
+            import_span,
+            module_span,
+            symbol,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
+            let offset = symbol.span.from;
+            Report::build(ReportKind::Error, path.clone(), offset)
+                .with_code("ImportNotFound")
+                .with_label(
+                    Label::new((path.clone(), module_span.into()))
+                        .with_message("In module this module."),
+                )
+                .with_label(
+                    Label::new((path.clone(), import_span.into()))
+                        .with_message("In this import statement"),
+                )
+                .with_label(
+                    Label::new((path, symbol.span.into()))
+                        .with_message(format!("Failed to find symbol {:?}", symbol.name))
+                        .with_color(colors.next()),
+                )
+                .with_message("Unresolved import.")
+                .finish()
+        }
+        LoweringError::BorrowNotMutable {
+            span,
+            name,
+            type_span,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
+            let mut labels = vec![Label::new((path.clone(), span.into()))
+                .with_message(format!(
+                    "Can't mutate {name:?} because it's behind a immutable borrow"
+                ))
+                .with_color(colors.next())];
 
             if let Some(type_span) = type_span {
-                labels.push(Label::new((path.clone(), type_span.into()))
-                .with_message(format!("Variable {name:?} has this type"))
-                .with_color(colors.next()));
+                labels.push(
+                    Label::new((path.clone(), type_span.into()))
+                        .with_message(format!("Variable {name:?} has this type"))
+                        .with_color(colors.next()),
+                );
             }
 
             Report::build(ReportKind::Error, path.clone(), span.from)
-            .with_code("BorrowNotMutable")
-            .with_labels(labels)
-            .finish()
-        },
-        LoweringError::UnrecognizedType { span, name } => {
+                .with_code("BorrowNotMutable")
+                .with_labels(labels)
+                .finish()
+        }
+        LoweringError::UnrecognizedType {
+            span,
+            name,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
                 .with_code("UnrecognizedType")
                 .with_label(
@@ -93,8 +125,13 @@ pub fn lowering_error_to_report(
                 )
                 .with_message(format!("Unresolved type {:?}.", name))
                 .finish()
-        },
-        LoweringError::IdNotFound { span, id } => {
+        }
+        LoweringError::IdNotFound {
+            span,
+            id,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
                 .with_code("E_ID")
                 .with_label(
@@ -104,8 +141,13 @@ pub fn lowering_error_to_report(
                 )
                 .with_message(format!("Failed to find definition id {id:?}, this is most likely a compiler bug or a unimplemented lowering"))
                 .finish()
-        },
-        LoweringError::NotYetImplemented { span, message } => {
+        }
+        LoweringError::NotYetImplemented {
+            span,
+            message,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
                 .with_code("NotYetImplemented")
                 .with_label(
@@ -114,19 +156,26 @@ pub fn lowering_error_to_report(
                         .with_color(colors.next()),
                 )
                 .finish()
-        },
-        LoweringError::UnexpectedType { span, found, expected } => {
-            let mut labels = vec![
-                Label::new((path.clone(), span.into()))
-                        .with_message(format!("Unexpected type '{}', expected '{}'", found.kind, expected.kind))
-                        .with_color(colors.next())
-            ];
+        }
+        LoweringError::UnexpectedType {
+            span,
+            found,
+            expected,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
+            let mut labels = vec![Label::new((path.clone(), span.into()))
+                .with_message(format!(
+                    "Unexpected type '{}', expected '{}'",
+                    found.kind, expected.kind
+                ))
+                .with_color(colors.next())];
 
             if let Some(span) = expected.span {
                 labels.push(
                     Label::new((path.clone(), span.into()))
                         .with_message(format!("expected '{}' due to this type", expected.kind))
-                        .with_color(colors.next())
+                        .with_color(colors.next()),
                 );
             }
 
@@ -135,26 +184,43 @@ pub fn lowering_error_to_report(
                 .with_labels(labels)
                 .with_message(format!("expected type {}.", expected.kind))
                 .finish()
-        },
-        LoweringError::UseOfUndeclaredVariable { span, name } => {
+        }
+        LoweringError::UseOfUndeclaredVariable {
+            span,
+            name,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
-            .with_code("UseOfUndeclaredVariable")
-            .with_label(
-                Label::new((path, span.into()))
-                    .with_message(format!("Use of undeclared variable {:?}", name))
-                    .with_color(colors.next()),
-            )
-            .finish()
-        },
-        LoweringError::ExternFnWithBody { span, name } => {
+                .with_code("UseOfUndeclaredVariable")
+                .with_label(
+                    Label::new((path, span.into()))
+                        .with_message(format!("Use of undeclared variable {:?}", name))
+                        .with_color(colors.next()),
+                )
+                .finish()
+        }
+        LoweringError::ExternFnWithBody {
+            span,
+            name,
+            program_id,
+        } => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
             Report::build(ReportKind::Error, path.clone(), span.from)
-            .with_code("ExternFnWithBody")
-            .with_label(
-                Label::new((path, span.into()))
-                    .with_message(format!("extern function {:?} declared with body", name))
-                    .with_color(colors.next()),
-            )
-            .finish()
-        },
+                .with_code("ExternFnWithBody")
+                .with_label(
+                    Label::new((path, span.into()))
+                        .with_message(format!("extern function {:?} declared with body", name))
+                        .with_color(colors.next()),
+                )
+                .finish()
+        }
+        LoweringError::InternalError(msg, program_id) => {
+            let path = file_paths[program_id].to_str().unwrap().to_string();
+            Report::build(ReportKind::Error, path.clone(), 0)
+                .with_code("InternalError")
+                .with_message(msg)
+                .finish()
+        }
     }
 }

--- a/crates/concrete_codegen_mlir/src/codegen.rs
+++ b/crates/concrete_codegen_mlir/src/codegen.rs
@@ -59,12 +59,12 @@ impl<'a> ModuleCodegenCtx<'a> {
     /// Gets a MLIR location from the given span, or unknown if the span is `None`.
     pub fn get_location(&self, span: Option<Span>) -> Location {
         if let Some(span) = span {
-            let (_, line, col) = self.ctx.session.source.get_offset_line(span.from).unwrap();
+            let (_, line, col) = self.ctx.session.sources[self.module_id.program_id]
+                .get_offset_line(span.from)
+                .unwrap();
             Location::new(
                 self.ctx.mlir_context,
-                self.ctx
-                    .session
-                    .file_path
+                self.ctx.program.file_paths[&self.module_id.program_id]
                     .file_name()
                     .unwrap()
                     .to_str()

--- a/crates/concrete_codegen_mlir/src/codegen.rs
+++ b/crates/concrete_codegen_mlir/src/codegen.rs
@@ -343,8 +343,10 @@ fn compile_function(ctx: FunctionCodegenCtx) -> Result<(), CodegenError> {
                         .iter()
                         .map(|x| compile_rvalue(&ctx, mlir_block, x, &locals).map(|x| x.0))
                         .collect::<Result<_, _>>()?;
-                    let fn_symbol =
-                        FlatSymbolRefAttribute::new(ctx.context(), &target_fn_body.name); // todo: good name resolution
+                    let fn_symbol = FlatSymbolRefAttribute::new(
+                        ctx.context(),
+                        &target_fn_body.get_mangled_name(),
+                    );
                     let ret_type = match &target_fn_body_sig.1.kind {
                         TyKind::Unit => None,
                         _ => Some(compile_type(ctx.module_ctx, &target_fn_body_sig.1)),
@@ -443,7 +445,7 @@ fn compile_function(ctx: FunctionCodegenCtx) -> Result<(), CodegenError> {
 
     let func_op = func::func(
         ctx.context(),
-        StringAttribute::new(ctx.context(), &body.name),
+        StringAttribute::new(ctx.context(), &body.get_mangled_name()),
         TypeAttribute::new(func_type.into()),
         region,
         &fn_attributes,

--- a/crates/concrete_codegen_mlir/src/context.rs
+++ b/crates/concrete_codegen_mlir/src/context.rs
@@ -39,8 +39,7 @@ impl Context {
         session: &Session,
         program: &ProgramBody,
     ) -> Result<MLIRModule, CodegenError> {
-        let file_path = session.file_path.display().to_string();
-        let location = Location::new(&self.melior_context, &file_path, 0, 0);
+        let location = Location::unknown(&self.melior_context);
         let target_triple = get_target_triple(session);
 
         let module_region = Region::new();
@@ -74,7 +73,7 @@ impl Context {
 
         super::codegen::compile_program(codegen_ctx)?;
 
-        if session.output_mlir || session.output_all {
+        if session.output_mlir {
             std::fs::write(
                 session.output_file.with_extension("before-pass.mlir"),
                 melior_module.as_operation().to_string(),
@@ -96,7 +95,7 @@ impl Context {
             );
         }
 
-        if session.output_mlir || session.output_all {
+        if session.output_mlir {
             std::fs::write(
                 session.output_file.with_extension("after-pass.mlir"),
                 melior_module.as_operation().to_string(),

--- a/crates/concrete_driver/Cargo.toml
+++ b/crates/concrete_driver/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.13", features = ["derive"] }
+clap = { version = "4.4.16", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 concrete_ast = { path = "../concrete_ast"}
@@ -17,6 +17,12 @@ salsa = { git = "https://github.com/salsa-rs/salsa.git", package = "salsa-2022" 
 ariadne = { version = "0.4.0", features = ["auto-color"] }
 concrete_ir = { version = "0.1.0", path = "../concrete_ir" }
 concrete_check = { version = "0.1.0", path = "../concrete_check" }
+walkdir = "2.5.0"
+anyhow = "1"
+toml = "0.8.10"
+git2 = "0.18.2"
+owo-colors = "4.0.0"
+serde = { version = "1.0.197", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.9.0"

--- a/crates/concrete_driver/src/config.rs
+++ b/crates/concrete_driver/src/config.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub package: Package,
+    pub profile: HashMap<String, Profile>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Package {
+    pub name: String,
+    pub version: String,
+    pub license: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Profile {
+    pub release: bool,
+    pub opt_level: u8,
+    pub debug_info: bool,
+}

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -25,7 +25,7 @@ pub mod db;
 pub mod linker;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about = "concrete", long_about = None, bin_name = "concrete")]
+#[command(author, version, about = "The Concrete Programming Language", long_about = None, bin_name = "concrete")]
 pub struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/crates/concrete_ir/src/lib.rs
+++ b/crates/concrete_ir/src/lib.rs
@@ -79,6 +79,18 @@ impl FnBody {
             .filter(|x| matches!(x.kind, LocalKind::Arg))
             .collect()
     }
+
+    pub fn get_mangled_name(&self) -> String {
+        if self.is_extern {
+            return self.name.clone();
+        }
+
+        if self.name == "main" {
+            "main".to_string()
+        } else {
+            format!("{}@{}@{}", self.name, self.id.program_id, self.id.id)
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/concrete_ir/src/lib.rs
+++ b/crates/concrete_ir/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt,
+    path::PathBuf,
 };
 
 use concrete_ast::common::Ident;
@@ -38,6 +39,8 @@ pub struct ProgramBody {
     pub structs: BTreeMap<DefId, AdtBody>,
     /// The function signatures.
     pub function_signatures: HashMap<DefId, (Vec<Ty>, Ty)>,
+    /// The file paths (program_id from the DefId) -> path.
+    pub file_paths: HashMap<usize, PathBuf>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/concrete_ir/src/lowering/errors.rs
+++ b/crates/concrete_ir/src/lowering/errors.rs
@@ -6,33 +6,74 @@ use crate::{DefId, Ty};
 #[derive(Debug, Error, Clone)]
 pub enum LoweringError {
     #[error("module {module:?} not found")]
-    ModuleNotFound { span: Span, module: String },
+    ModuleNotFound {
+        span: Span,
+        module: String,
+        program_id: usize,
+    },
     #[error("function {function:?} not found")]
-    FunctionNotFound { span: Span, function: String },
+    FunctionNotFound {
+        span: Span,
+        function: String,
+        program_id: usize,
+    },
     #[error("struct field {name:?} not found")]
-    StructFieldNotFound { span: Span, name: String },
+    StructFieldNotFound {
+        span: Span,
+        name: String,
+        program_id: usize,
+    },
     #[error("symbol {:?} not found", symbol.name)]
     ImportNotFound {
         module_span: Span,
         import_span: Span,
         symbol: Ident,
+        program_id: usize,
     },
     #[error("use of underclared variable {name:?}")]
-    UseOfUndeclaredVariable { span: Span, name: String },
+    UseOfUndeclaredVariable {
+        span: Span,
+        name: String,
+        program_id: usize,
+    },
     #[error("trying to mutate a non-mutable reference")]
     BorrowNotMutable {
         span: Span,
         type_span: Option<Span>,
         name: String,
+        program_id: usize,
     },
     #[error("unrecognized type {name}")]
-    UnrecognizedType { span: Span, name: String },
+    UnrecognizedType {
+        span: Span,
+        name: String,
+        program_id: usize,
+    },
     #[error("id not found")]
-    IdNotFound { span: Span, id: DefId },
+    IdNotFound {
+        span: Span,
+        id: DefId,
+        program_id: usize,
+    },
     #[error("feature not yet implemented: {message}")]
-    NotYetImplemented { span: Span, message: &'static str },
+    NotYetImplemented {
+        span: Span,
+        message: &'static str,
+        program_id: usize,
+    },
     #[error("unexpected type")]
-    UnexpectedType { span: Span, found: Ty, expected: Ty },
+    UnexpectedType {
+        span: Span,
+        found: Ty,
+        expected: Ty,
+        program_id: usize,
+    },
     #[error("extern function {name:?} has a body")]
-    ExternFnWithBody { span: Span, name: String },
+    ExternFnWithBody {
+        span: Span,
+        name: String,
+        program_id: usize,
+    },
+    #[error("internal error: {0}")]
+    InternalError(String, usize),
 }

--- a/crates/concrete_ir/src/lowering/prepass.rs
+++ b/crates/concrete_ir/src/lowering/prepass.rs
@@ -261,6 +261,7 @@ pub fn prepass_imports(
             .ok_or(LoweringError::ModuleNotFound {
                 span: import.module[0].span,
                 module: import.module[0].name.clone(),
+                program_id: mod_id.program_id,
             })?;
         let mut imported_module =
             ctx.body
@@ -269,6 +270,7 @@ pub fn prepass_imports(
                 .ok_or(LoweringError::IdNotFound {
                     span: mod_def.span,
                     id: *imported_module_id,
+                    program_id: mod_id.program_id,
                 })?;
 
         for x in import.module.iter().skip(1) {
@@ -280,11 +282,13 @@ pub fn prepass_imports(
                     .ok_or_else(|| LoweringError::ModuleNotFound {
                         span: x.span,
                         module: x.name.clone(),
+                        program_id: mod_id.program_id,
                     })?;
             imported_module = ctx.body.modules.get(imported_module_id).ok_or({
                 LoweringError::IdNotFound {
                     span: x.span,
                     id: *imported_module_id,
+                    program_id: mod_id.program_id,
                 }
             })?;
         }
@@ -305,6 +309,7 @@ pub fn prepass_imports(
                     module_span: mod_def.span,
                     import_span: import.span,
                     symbol: sym.clone(),
+                    program_id: mod_id.program_id,
                 })?;
             }
         }
@@ -338,6 +343,7 @@ pub fn prepass_imports_submodule(
         .ok_or(LoweringError::IdNotFound {
             span: mod_def.span,
             id: parent_id,
+            program_id: parent_id.program_id,
         })?
         .symbols
         .modules
@@ -345,6 +351,7 @@ pub fn prepass_imports_submodule(
         .ok_or_else(|| LoweringError::ModuleNotFound {
             span: mod_def.span,
             module: mod_def.name.name.clone(),
+            program_id: parent_id.program_id,
         })?;
 
     for import in &mod_def.imports {
@@ -355,6 +362,7 @@ pub fn prepass_imports_submodule(
             .ok_or_else(|| LoweringError::ModuleNotFound {
                 span: import.module[0].span,
                 module: import.module[0].name.clone(),
+                program_id: parent_id.program_id,
             })?;
         let mut imported_module =
             ctx.body
@@ -363,6 +371,7 @@ pub fn prepass_imports_submodule(
                 .ok_or(LoweringError::IdNotFound {
                     span: import.span,
                     id: *imported_module_id,
+                    program_id: parent_id.program_id,
                 })?;
 
         for module_path in import.module.iter().skip(1) {
@@ -373,11 +382,13 @@ pub fn prepass_imports_submodule(
                 .ok_or_else(|| LoweringError::ModuleNotFound {
                     span: module_path.span,
                     module: module_path.name.clone(),
+                    program_id: parent_id.program_id,
                 })?;
             imported_module = ctx.body.modules.get(imported_module_id).ok_or({
                 LoweringError::IdNotFound {
                     span: import.span,
                     id: *imported_module_id,
+                    program_id: parent_id.program_id,
                 }
             })?;
         }
@@ -398,6 +409,7 @@ pub fn prepass_imports_submodule(
                     module_span: mod_def.span,
                     import_span: import.span,
                     symbol: sym.clone(),
+                    program_id: parent_id.program_id,
                 })?;
             }
         }
@@ -408,6 +420,7 @@ pub fn prepass_imports_submodule(
             .ok_or(LoweringError::IdNotFound {
                 span: mod_def.span,
                 id: mod_id,
+                program_id: mod_id.program_id,
             })?
             .imports
             .extend(imports);

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -184,6 +184,7 @@ pub(crate) GenericParams: Vec<ast::common::GenericParam> = {
 pub Program: ast::Program = {
   <Module> => {
     ast::Program {
+      file_path: None,
       modules: vec![<>],
     }
   },

--- a/crates/concrete_session/src/lib.rs
+++ b/crates/concrete_session/src/lib.rs
@@ -7,19 +7,15 @@ pub mod config;
 
 #[derive(Debug, Clone)]
 pub struct Session {
-    pub file_path: PathBuf,
     pub debug_info: DebugInfo,
     pub optlevel: OptLevel,
-    pub source: Source<String>, // for debugging locations
+    pub sources: Vec<Source>, // for debugging locations
     /// True if it should be compiled as a library false for binary.
     pub library: bool,
-    /// The directory where to store artifacts and intermediate files such as object files.
-    pub target_dir: PathBuf,
     pub output_file: PathBuf,
     pub output_mlir: bool,
     pub output_ll: bool,
     pub output_asm: bool,
-    pub output_all: bool,
     // todo: include target, host, etc
 }
 


### PR DESCRIPTION
```
❯ concrete

Usage: concrete <COMMAND>

Commands:
  new    Initialize a project
  build  Build a project
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

```
❯ concrete new --help
Initialize a project

Usage: concrete new [OPTIONS] <PATH>

Arguments:
  <PATH>  

Options:
      --name <NAME>  The name of the project, defaults to the directory name
      --bin          Use a binary (application) template [default]
      --lib          Use a library template
  -h, --help         Print help
```

```
❯ concrete build --help
Build a project

Usage: concrete build [OPTIONS]

Options:
  -r, --release            Build for release with all optimizations
  -p, --profile <PROFILE>  Override the profile to use
  -h, --help               Print help
```