### PR TITLE
Add script for setting env vars in mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ export LLVM_SYS_170_PREFIX=/usr/lib/llvm-17
 export TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 ```
 
-If you installed llvm with brew, set up the env vars with the following script:
+If you installed llvm with brew, source the `env-macos.sh` script to set up the needed env vars:
 ```sh
 source scripts/env-macos.sh
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ export LLVM_SYS_170_PREFIX=/usr/lib/llvm-17
 export TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 ```
 
+If you installed llvm with brew, set up the env vars with the following script:
+```sh
+source scripts/env-macos.sh
+```
+
 ## Table of Contents
 
 - [Design](#design)

--- a/scripts/env-macos.sh
+++ b/scripts/env-macos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This script is only useful on macOS using brew.
+# It sets the LLVM environment variables.
+
+MLIR_SYS_170_PREFIX="$(brew --prefix llvm@17)"
+LLVM_SYS_170_PREFIX="$(brew --prefix llvm@17)"
+TABLEGEN_170_PREFIX="$(brew --prefix llvm@17)"
+
+export MLIR_SYS_170_PREFIX
+export LLVM_SYS_170_PREFIX
+export TABLEGEN_170_PREFIX


### PR DESCRIPTION
Adds a script to set up env vars if installed with brew (copied from cairo native) and updates the readme.md to include instructions on how to use it.