### PR TITLE
Add run command to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ target/
 .vscode/
 lcov.info
 
-build_artifacts/
+build/
 
 *.so
 *.a

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -292,7 +292,7 @@ mod {} {{
                 None => build_command(profile, release)?,
             };
 
-            Err(std::process::Command::new(&output).exec())?;
+            Err(std::process::Command::new(output).exec())?;
         }
     }
 

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -139,7 +139,7 @@ pub fn main() -> Result<()> {
         } => {
             let name = name.unwrap_or_else(|| {
                 path.file_name()
-                    .context("Failed to get project name")
+                    .context("failed to get project name")
                     .unwrap()
                     .to_string_lossy()
                     .to_string()
@@ -324,7 +324,7 @@ fn build_command(profile: Option<String>, release: bool) -> Result<PathBuf> {
             current_dir = if let Some(parent) = current_dir.parent() {
                 parent.to_path_buf()
             } else {
-                bail!("Couldn't find Concrete.toml");
+                bail!("couldn't find Concrete.toml");
             };
         } else {
             config_path = Some(current_dir.join("Concrete.toml"));
@@ -333,12 +333,12 @@ fn build_command(profile: Option<String>, release: bool) -> Result<PathBuf> {
     }
     let config_path = match config_path {
         Some(x) => x,
-        None => bail!("Couldn't find Concrete.toml"),
+        None => bail!("couldn't find Concrete.toml"),
     };
     let base_dir = config_path
         .parent()
         .context("couldn't get config parent dir")?;
-    let mut config = File::open(&config_path).context("Failed to open Concrete.toml")?;
+    let mut config = File::open(&config_path).context("failed to open Concrete.toml")?;
     let mut buf = String::new();
     config.read_to_string(&mut buf)?;
     let config: Config = toml::from_str(&buf).context("failed to parse Concrete.toml")?;
@@ -361,7 +361,7 @@ fn build_command(profile: Option<String>, release: bool) -> Result<PathBuf> {
             config
                 .profile
                 .get(&profile)
-                .context("Couldn't get requested profile")?,
+                .context("couldn't get requested profile")?,
             profile,
         )
     } else if release {
@@ -369,7 +369,7 @@ fn build_command(profile: Option<String>, release: bool) -> Result<PathBuf> {
             config
                 .profile
                 .get("release")
-                .context("Couldn't get profile: release")?,
+                .context("couldn't get profile: release")?,
             "release".to_string(),
         )
     } else {
@@ -377,7 +377,7 @@ fn build_command(profile: Option<String>, release: bool) -> Result<PathBuf> {
             config
                 .profile
                 .get("dev")
-                .context("Couldn't get profile: dev")?,
+                .context("couldn't get profile: dev")?,
             "dev".to_string(),
         )
     };

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -12,6 +12,7 @@ use config::{Package, Profile};
 use git2::{IndexAddOption, Repository};
 use owo_colors::OwoColorize;
 use std::io::Read;
+use std::os::unix::process::CommandExt;
 use std::{collections::HashMap, fs::File, path::PathBuf, time::Instant};
 use walkdir::WalkDir;
 
@@ -383,6 +384,8 @@ mod {} {{
             let object = compile(&compile_args)?;
 
             link_binary(&[object], &output)?;
+
+            Err(std::process::Command::new(&output).exec())?;
         }
     }
 

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -364,7 +364,12 @@ mod {} {{
                 .context("could not get file stem")?
                 .to_str()
                 .context("could not convert file stem to string")?;
-            let output = std::env::current_dir()?.join("build").join(stem);
+
+            let build_dir = std::env::current_dir()?.join("build");
+            if !build_dir.exists() {
+                std::fs::create_dir_all(&build_dir)?;
+            }
+            let output = build_dir.with_file_name(stem);
 
             let compile_args = CompilerArgs {
                 input,
@@ -380,10 +385,7 @@ mod {} {{
                 object: true,
                 mlir: true,
             };
-
-            let start = Instant::now();
             let object = compile(&compile_args)?;
-
             link_binary(&[object], &output)?;
         }
     }

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -60,10 +60,7 @@ enum Commands {
         profile: Option<String>,
     },
     /// Run a concrete file
-    Run {
-        #[arg(required = false)]
-        path: Option<PathBuf>,
-    },
+    Run { path: PathBuf },
 }
 
 #[derive(Parser, Debug)]
@@ -356,9 +353,7 @@ mod {} {{
                 }
             );
         }
-        Commands::Run { path } => {
-            let input = path.unwrap();
-
+        Commands::Run { path: input } => {
             let output_stem = input
                 .file_stem()
                 .context("could not get file stem")?

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -267,7 +267,7 @@ mod {} {{
                     if !build_dir.exists() {
                         std::fs::create_dir_all(&build_dir)?;
                     }
-                    let output = build_dir.join(&input_stem);
+                    let output = build_dir.join(input_stem);
 
                     let compile_args = CompilerArgs {
                         input: input.clone(),

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -359,7 +359,7 @@ mod {} {{
         Commands::Run { path } => {
             let input = path.unwrap();
 
-            let stem = input
+            let output_stem = input
                 .file_stem()
                 .context("could not get file stem")?
                 .to_str()
@@ -369,7 +369,7 @@ mod {} {{
             if !build_dir.exists() {
                 std::fs::create_dir_all(&build_dir)?;
             }
-            let output = build_dir.with_file_name(stem);
+            let output = build_dir.join(output_stem);
 
             let compile_args = CompilerArgs {
                 input,
@@ -386,6 +386,7 @@ mod {} {{
                 mlir: true,
             };
             let object = compile(&compile_args)?;
+
             link_binary(&[object], &output)?;
         }
     }

--- a/examples/project/Concrete.toml
+++ b/examples/project/Concrete.toml
@@ -1,0 +1,14 @@
+[package]
+name = "project"
+version = "0.1.0"
+license = "MIT"
+
+[profile.release]
+release = true
+opt_level = 3
+debug_info = false
+
+[profile.dev]
+release = false
+opt_level = 0
+debug_info = true

--- a/examples/project/src/main.con
+++ b/examples/project/src/main.con
@@ -1,0 +1,6 @@
+
+mod project {
+    pub fn main() -> i32 {
+        return 17;
+    }
+}


### PR DESCRIPTION
- Adds `run` command to CLI
  - if no path is sent, it runs the current project's main (like build, but also running the binary)
  - if a path is sent, it builds and runs that concrete file in single file mode.
- Adds an example project, can be used to test the run command in project mode.

Example usage:

```sh
cargo run -- run examples/fib_if.con
# or
concrete run examples/fib_if.con
```

tip: to install the binary, run:
```sh
cargo install --path crates/concrete
```