### PR TITLE
Fix #107 Control Flow Bug

### DIFF
--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -17,6 +17,7 @@ mod common;
 #[test_case(include_str!("../../../examples/casts.con"), "casts", false, 2 ; "casts.con")]
 #[test_case(include_str!("../../../examples/malloc.con"), "malloc", false, 5 ; "malloc.con")]
 #[test_case(include_str!("../../../examples/while_if_false.con"), "while_if_false", false, 7 ; "while_if_false.con")]
+#[test_case(include_str!("../../../examples/if_if_false.con"), "if_if_false", false, 7 ; "if_if_false.con")]
 fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     assert_eq!(
         status_code,

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -16,6 +16,7 @@ mod common;
 #[test_case(include_str!("../../../examples/structs.con"), "structs", false, 8 ; "structs.con")]
 #[test_case(include_str!("../../../examples/casts.con"), "casts", false, 2 ; "casts.con")]
 #[test_case(include_str!("../../../examples/malloc.con"), "malloc", false, 5 ; "malloc.con")]
+#[test_case(include_str!("../../../examples/while_if_false.con"), "while_if_false", false, 7 ; "while_if_false.con")]
 fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     assert_eq!(
         status_code,

--- a/crates/concrete_ir/src/lowering.rs
+++ b/crates/concrete_ir/src/lowering.rs
@@ -366,12 +366,18 @@ fn lower_statement(
         statements::Statement::Assign(info) => lower_assign(builder, info)?,
         statements::Statement::Match(_) => todo!(),
         statements::Statement::For(_) => todo!(),
-        statements::Statement::If(info) => lower_if_statement(builder, info)?,
+        statements::Statement::If(info) => {
+            lower_if_statement(builder, info)?;
+            assert!(builder.statements.is_empty());
+        }
         statements::Statement::Let(info) => lower_let(builder, info)?,
         statements::Statement::Return(info) => {
             lower_return(builder, info, ret_type)?;
         }
-        statements::Statement::While(info) => lower_while(builder, info)?,
+        statements::Statement::While(info) => {
+            lower_while(builder, info)?;
+            assert!(builder.statements.is_empty());
+        }
         statements::Statement::FnCall(info) => {
             lower_fn_call(builder, info)?;
         }

--- a/examples/if_if_false.con
+++ b/examples/if_if_false.con
@@ -1,0 +1,15 @@
+mod Example {
+    fn main() -> i32 {
+        let foo: i32 = 7;
+
+        if true {
+            if false {
+                return 1;
+            }
+        } else {
+            foo = 14;
+        }
+
+        return foo;
+    }
+}

--- a/examples/while_if_false.con
+++ b/examples/while_if_false.con
@@ -1,0 +1,14 @@
+mod Example {
+    fn main() -> i32 {
+        let mut result: i32 = 7;
+
+        while false {
+            if false {
+                return 0;
+            }
+            result = 14;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
closes #107

- Enforces that no statements are left unpushed after lowering an if or a while
- Always add a goto "loop check" at the end of loop blocks
- Always add a goto "end of if" at the end of each if branch
- Always add an implicit return at the end of a function