### PR TITLE
Add more type and mutability checks

### DIFF
--- a/crates/concrete_check/src/lib.rs
+++ b/crates/concrete_check/src/lib.rs
@@ -222,5 +222,51 @@ pub fn lowering_error_to_report(
                 .with_message(msg)
                 .finish()
         }
+        LoweringError::NotMutable {
+            span,
+            declare_span,
+            program_id,
+        } => {
+            let path = file_paths[program_id].display().to_string();
+            let mut report = Report::build(ReportKind::Error, path.clone(), span.from)
+                .with_code("NotMutable")
+                .with_label(
+                    Label::new((path.clone(), span.into()))
+                        .with_message("can't mutate this variable because it's not mutable")
+                        .with_color(colors.next()),
+                );
+
+            if let Some(declare_span) = declare_span {
+                report = report.with_label(
+                    Label::new((path, declare_span.into()))
+                        .with_message("variable declared here")
+                        .with_color(colors.next()),
+                );
+            }
+            report.finish()
+        }
+        LoweringError::CantTakeMutableBorrow {
+            span,
+            declare_span,
+            program_id,
+        } => {
+            let path = file_paths[program_id].display().to_string();
+            let mut report = Report::build(ReportKind::Error, path.clone(), span.from)
+                .with_code("CantTakeMutableBorrow")
+                .with_label(
+                    Label::new((path.clone(), span.into()))
+                        .with_message("can't take a mutate borrow to this variable because it's not declared mutable")
+                        .with_color(colors.next()),
+                );
+
+            if let Some(declare_span) = declare_span {
+                report = report.with_label(
+                    Label::new((path, declare_span.into()))
+                        .with_message("variable declared here")
+                        .with_color(colors.next()),
+                );
+            }
+            report.finish()
+        }
     }
 }

--- a/crates/concrete_driver/tests/checks.rs
+++ b/crates/concrete_driver/tests/checks.rs
@@ -35,14 +35,14 @@ fn import_not_found() {
 
 #[test]
 fn invalid_borrow_mut() {
-    let (source, name) = (include_str!("invalid_programs/refmut.con"), "refmut");
+    let (source, name) = (
+        include_str!("invalid_programs/invalid_borrow_mut.con"),
+        "invalid_borrow_mut",
+    );
     let error = check_invalid_program(source, name);
 
     assert!(
-        matches!(
-            &error,
-            LoweringError::BorrowNotMutable { name, .. } if name == "a"
-        ),
+        matches!(&error, LoweringError::NotMutable { .. }),
         "{:#?}",
         error
     );
@@ -98,6 +98,51 @@ fn undeclared_var() {
             &error,
             LoweringError::UseOfUndeclaredVariable { name, .. } if name == "b"
         ),
+        "{:#?}",
+        error
+    );
+}
+
+#[test]
+fn invalid_assign() {
+    let (source, name) = (
+        include_str!("invalid_programs/invalid_assign.con"),
+        "invalid_assign",
+    );
+    let error = check_invalid_program(source, name);
+
+    assert!(
+        matches!(&error, LoweringError::UnexpectedType { .. }),
+        "{:#?}",
+        error
+    );
+}
+
+#[test]
+fn immutable_mutation() {
+    let (source, name) = (
+        include_str!("invalid_programs/immutable_mutation.con"),
+        "immutable_mutation",
+    );
+    let error = check_invalid_program(source, name);
+
+    assert!(
+        matches!(&error, LoweringError::NotMutable { .. }),
+        "{:#?}",
+        error
+    );
+}
+
+#[test]
+fn mutable_nonmut_borrow() {
+    let (source, name) = (
+        include_str!("invalid_programs/mutable_nonmut_borrow.con"),
+        "mutable_nonmut_borrow",
+    );
+    let error = check_invalid_program(source, name);
+
+    assert!(
+        matches!(&error, LoweringError::CantTakeMutableBorrow { .. }),
         "{:#?}",
         error
     );

--- a/crates/concrete_driver/tests/invalid_programs/immutable_mutation.con
+++ b/crates/concrete_driver/tests/invalid_programs/immutable_mutation.con
@@ -1,0 +1,7 @@
+mod Simple {
+    fn main() -> i32 {
+        let x: i32 = 2;
+        x = 4;
+        return x;
+    }
+}

--- a/crates/concrete_driver/tests/invalid_programs/invalid_assign.con
+++ b/crates/concrete_driver/tests/invalid_programs/invalid_assign.con
@@ -1,0 +1,8 @@
+mod Simple {
+    fn main() -> i32 {
+        let mut x: i32 = 2;
+        let y: i64 = 4;
+        x = y;
+        return x;
+    }
+}

--- a/crates/concrete_driver/tests/invalid_programs/invalid_borrow_mut.con
+++ b/crates/concrete_driver/tests/invalid_programs/invalid_borrow_mut.con
@@ -1,7 +1,7 @@
 mod Simple {
 
     fn main() -> i32 {
-        let x: i32 = 1;
+        let mut x: i32 = 1;
         hello(&x);
         return x;
     }

--- a/crates/concrete_driver/tests/invalid_programs/mutable_nonmut_borrow.con
+++ b/crates/concrete_driver/tests/invalid_programs/mutable_nonmut_borrow.con
@@ -1,0 +1,8 @@
+mod Simple {
+    fn main() -> i32 {
+        let x: i32 = 2;
+        let y: &mut i32 = &mut x;
+        *y = 4;
+        return *y;
+    }
+}

--- a/crates/concrete_ir/src/lib.rs
+++ b/crates/concrete_ir/src/lib.rs
@@ -178,11 +178,31 @@ pub enum Rvalue {
     Cast(Operand, Ty, Span),
 }
 
+impl Rvalue {
+    pub fn get_local(&self) -> Option<usize> {
+        match self {
+            Rvalue::Use(op) => op.get_local(),
+            Rvalue::Ref(_, op) => Some(op.local),
+            Rvalue::Cast(op, _, _) => op.get_local(),
+            _ => None,
+        }
+    }
+}
+
 /// A operand is a value, either from a place in memory or constant data.
 #[derive(Debug, Clone)]
 pub enum Operand {
     Place(Place),
     Const(ConstData),
+}
+
+impl Operand {
+    pub fn get_local(&self) -> Option<usize> {
+        match self {
+            Operand::Place(place) => Some(place.local),
+            Operand::Const(_) => None,
+        }
+    }
 }
 
 /// A place in memory, defined by the given local and it's projection (deref, field, index, etc).
@@ -216,15 +236,24 @@ pub struct Local {
     pub ty: Ty,
     /// The type of local.
     pub kind: LocalKind,
+    /// Whether this local is declared mutable.
+    pub mutable: bool,
 }
 
 impl Local {
-    pub fn new(span: Option<Span>, kind: LocalKind, ty: Ty, debug_name: Option<String>) -> Self {
+    pub fn new(
+        span: Option<Span>,
+        kind: LocalKind,
+        ty: Ty,
+        debug_name: Option<String>,
+        mutable: bool,
+    ) -> Self {
         Self {
             span,
             kind,
             ty,
             debug_name,
+            mutable,
         }
     }
 
@@ -234,6 +263,19 @@ impl Local {
             ty,
             kind: LocalKind::Temp,
             debug_name: None,
+            mutable: false,
+        }
+    }
+
+    pub fn is_mutable(&self) -> bool {
+        if self.mutable {
+            return true;
+        }
+
+        match self.ty.kind {
+            TyKind::Ptr(_, is_mut) => matches!(is_mut, Mutability::Mut),
+            TyKind::Ref(_, is_mut) => matches!(is_mut, Mutability::Mut),
+            _ => false,
         }
     }
 }

--- a/crates/concrete_ir/src/lowering.rs
+++ b/crates/concrete_ir/src/lowering.rs
@@ -258,10 +258,13 @@ fn lower_func(
         .clone();
 
     builder.ret_local = builder.body.locals.len();
-    builder
-        .body
-        .locals
-        .push(Local::new(None, LocalKind::ReturnPointer, ret_ty, None));
+    builder.body.locals.push(Local::new(
+        None,
+        LocalKind::ReturnPointer,
+        ret_ty,
+        None,
+        false,
+    ));
 
     for (arg, ty) in func.decl.params.iter().zip(args_ty) {
         builder
@@ -272,6 +275,7 @@ fn lower_func(
             LocalKind::Arg,
             ty,
             Some(arg.name.name.clone()),
+            false,
         ));
     }
 
@@ -289,6 +293,7 @@ fn lower_func(
                         LocalKind::Temp,
                         ty,
                         Some(name.name.clone()),
+                        info.is_mutable,
                     ));
                 }
                 LetStmtTarget::Destructure(_) => todo!(),
@@ -306,6 +311,7 @@ fn lower_func(
                             LocalKind::Temp,
                             ty,
                             Some(name.name.clone()),
+                            info.is_mutable,
                         ));
                     }
                     LetStmtTarget::Destructure(_) => todo!(),
@@ -684,12 +690,12 @@ fn lower_let(builder: &mut FnBodyBuilder, info: &LetStmt) -> Result<(), Lowering
     match &info.target {
         LetStmtTarget::Simple { name, r#type } => {
             let ty = lower_type(&builder.ctx, r#type, builder.local_module)?;
-            let (rvalue, rvalue_ty, _exp_span) =
+            let (rvalue, rvalue_ty, rvalue_span) =
                 lower_expression(builder, &info.value, Some(ty.clone()))?;
 
             if ty.kind != rvalue_ty.kind {
                 return Err(LoweringError::UnexpectedType {
-                    span: info.span,
+                    span: rvalue_span,
                     found: rvalue_ty,
                     expected: ty.clone(),
                     program_id: builder.local_module.program_id,
@@ -720,6 +726,14 @@ fn lower_let(builder: &mut FnBodyBuilder, info: &LetStmt) -> Result<(), Lowering
 fn lower_assign(builder: &mut FnBodyBuilder, info: &AssignStmt) -> Result<(), LoweringError> {
     let (mut place, mut ty, _path_span) = lower_path(builder, &info.target)?;
 
+    if !builder.body.locals[place.local].is_mutable() {
+        return Err(LoweringError::NotMutable {
+            span: info.span,
+            declare_span: builder.body.locals[place.local].span,
+            program_id: builder.body.id.program_id,
+        });
+    }
+
     for _ in 0..info.derefs {
         match &ty.kind {
             TyKind::Ref(inner, is_mut) | TyKind::Ptr(inner, is_mut) => {
@@ -738,7 +752,17 @@ fn lower_assign(builder: &mut FnBodyBuilder, info: &AssignStmt) -> Result<(), Lo
         place.projection.push(PlaceElem::Deref);
     }
 
-    let (rvalue, _rvalue_ty, _exp_span) = lower_expression(builder, &info.value, Some(ty.clone()))?;
+    let (rvalue, rvalue_ty, rvalue_span) =
+        lower_expression(builder, &info.value, Some(ty.clone()))?;
+
+    if ty.kind != rvalue_ty.kind {
+        return Err(LoweringError::UnexpectedType {
+            span: rvalue_span,
+            found: rvalue_ty,
+            expected: ty.clone(),
+            program_id: builder.local_module.program_id,
+        });
+    }
 
     builder.statements.push(Statement {
         span: Some(info.target.first.span),
@@ -935,7 +959,17 @@ fn lower_expression(
                 },
                 None => None,
             };
-            let (value, ty, _span) = lower_expression(builder, inner, type_hint)?;
+            let (value, ty, _ref_target_span) = lower_expression(builder, inner, type_hint)?;
+
+            if let Some(local) = value.get_local() {
+                if *mutable && !builder.body.locals[local].mutable {
+                    return Err(LoweringError::CantTakeMutableBorrow {
+                        span: *asref_span,
+                        declare_span: builder.body.locals[local].span,
+                        program_id: builder.body.id.program_id,
+                    });
+                }
+            }
 
             let mutability = match mutable {
                 false => Mutability::Not,

--- a/crates/concrete_ir/src/lowering/errors.rs
+++ b/crates/concrete_ir/src/lowering/errors.rs
@@ -43,6 +43,18 @@ pub enum LoweringError {
         name: String,
         program_id: usize,
     },
+    #[error("can't mutate this value because it's not declared mutable")]
+    NotMutable {
+        span: Span,
+        declare_span: Option<Span>,
+        program_id: usize,
+    },
+    #[error("can't take a mutable borrow to this value because it's not declared mutable")]
+    CantTakeMutableBorrow {
+        span: Span,
+        declare_span: Option<Span>,
+        program_id: usize,
+    },
     #[error("unrecognized type {name}")]
     UnrecognizedType {
         span: Span,

--- a/examples/for.con
+++ b/examples/for.con
@@ -6,7 +6,7 @@ mod Example {
     fn sum_to(limit: i64) -> i64 {
         let mut result: i64 = 0;
 
-        for (let n: i64 = 1; n <= limit; n = n + 1) {
+        for (let mut n: i64 = 1; n <= limit; n = n + 1) {
             result = result + n;
         }
 

--- a/examples/for_while.con
+++ b/examples/for_while.con
@@ -6,7 +6,7 @@ mod Example {
     fn sum_to(limit: i64) -> i64 {
         let mut result: i64 = 0;
 
-        let n: i64 = 1;
+        let mut n: i64 = 1;
         for (n <= limit) {
             result = result + n;
             n = n + 1;

--- a/examples/if_if_false.con
+++ b/examples/if_if_false.con
@@ -1,6 +1,6 @@
 mod Example {
     fn main() -> i32 {
-        let foo: i32 = 7;
+        let mut foo: i32 = 7;
 
         if true {
             if false {


### PR DESCRIPTION
Checks if a variable is declared mutable and if not, if its being mutated.

Checks for valid mutable borrows (but doesnt check for multiple mutable borrows yet).

![image](https://github.com/lambdaclass/concrete/assets/15859336/ffa7e0e9-501c-441a-a67c-aa38aca9c840)

![image](https://github.com/lambdaclass/concrete/assets/15859336/44e48445-37ab-47a3-811a-3bc113adeac3)
