### PR TITLE
Add pointer offsetting (add) and intrinsic parsing

### DIFF
--- a/crates/concrete_ast/src/common.rs
+++ b/crates/concrete_ast/src/common.rs
@@ -37,3 +37,10 @@ pub struct GenericParam {
     pub params: Vec<TypeSpec>,
     pub span: Span,
 }
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct Attribute {
+    pub name: String,
+    pub value: Option<String>,
+    pub span: Span,
+}

--- a/crates/concrete_ast/src/functions.rs
+++ b/crates/concrete_ast/src/functions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{DocString, GenericParam, Ident, Span},
+    common::{Attribute, DocString, GenericParam, Ident, Span},
     statements::Statement,
     types::TypeSpec,
 };
@@ -13,6 +13,7 @@ pub struct FunctionDecl {
     pub ret_type: Option<TypeSpec>,
     pub is_extern: bool,
     pub is_pub: bool,
+    pub attributes: Vec<Attribute>,
     pub span: Span,
 }
 

--- a/crates/concrete_codegen_mlir/src/errors.rs
+++ b/crates/concrete_codegen_mlir/src/errors.rs
@@ -8,4 +8,6 @@ pub enum CodegenError {
     LLVMCompileError(String),
     #[error("melior error: {0}")]
     MeliorError(#[from] melior::Error),
+    #[error("not yet implemented: {0}")]
+    NotImplemented(String),
 }

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     fmt,
     path::{Path, PathBuf},
-    process::Output,
+    process::{Output, Stdio},
 };
 
 use ariadne::Source;
@@ -110,6 +110,7 @@ pub fn compile_program(
 
 pub fn run_program(program: &Path) -> Result<Output, std::io::Error> {
     std::process::Command::new(program)
+        .stdout(Stdio::piped())
         .spawn()?
         .wait_with_output()
 }
@@ -121,4 +122,19 @@ pub fn compile_and_run(source: &str, name: &str, library: bool, optlevel: OptLev
     let output = run_program(&result.binary_file).expect("failed to run");
 
     output.status.code().unwrap()
+}
+
+#[allow(unused)] // false positive
+#[track_caller]
+pub fn compile_and_run_output(
+    source: &str,
+    name: &str,
+    library: bool,
+    optlevel: OptLevel,
+) -> String {
+    let result = compile_program(source, name, library, optlevel).expect("failed to compile");
+
+    let output = run_program(&result.binary_file).expect("failed to run");
+
+    std::str::from_utf8(&output.stdout).unwrap().to_string()
 }

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -1,4 +1,4 @@
-use crate::common::compile_and_run;
+use crate::common::{compile_and_run, compile_and_run_output};
 use concrete_session::config::OptLevel;
 use test_case::test_case;
 
@@ -37,5 +37,25 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Aggressive)
+    );
+}
+
+#[test_case(include_str!("../../../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
+fn example_tests_with_output(source: &str, name: &str, is_library: bool, result: &str) {
+    assert_eq!(
+        result,
+        compile_and_run_output(source, name, is_library, OptLevel::None)
+    );
+    assert_eq!(
+        result,
+        compile_and_run_output(source, name, is_library, OptLevel::Less)
+    );
+    assert_eq!(
+        result,
+        compile_and_run_output(source, name, is_library, OptLevel::Default)
+    );
+    assert_eq!(
+        result,
+        compile_and_run_output(source, name, is_library, OptLevel::Aggressive)
     );
 }

--- a/crates/concrete_ir/src/lib.rs
+++ b/crates/concrete_ir/src/lib.rs
@@ -68,6 +68,7 @@ pub struct FnBody {
     pub id: DefId,
     pub name: String,
     pub is_extern: bool,
+    pub is_intrinsic: Option<ConcreteIntrinsic>,
     pub basic_blocks: Vec<BasicBlock>,
     pub locals: Vec<Local>,
 }
@@ -397,7 +398,15 @@ impl fmt::Display for TyKind {
                 FloatTy::F64 => write!(f, "f32"),
             },
             TyKind::String => write!(f, "string"),
-            TyKind::Array(_, _) => todo!(),
+            TyKind::Array(inner, size) => {
+                let value =
+                    if let ConstKind::Value(ValueTree::Leaf(ConstValue::U64(x))) = &size.data {
+                        *x
+                    } else {
+                        unreachable!("const data for array sizes should always be u64")
+                    };
+                write!(f, "[{}; {:?}]", inner.kind, value)
+            }
             TyKind::Ref(inner, is_mut) => {
                 let word = if let Mutability::Mut = is_mut {
                     "mut"
@@ -570,4 +579,9 @@ pub enum ConstValue {
     U128(u128),
     F32(f32),
     F64(f64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum ConcreteIntrinsic {
+    // Todo: Add intrinsics here
 }

--- a/crates/concrete_parser/src/grammar.lalrpop
+++ b/crates/concrete_parser/src/grammar.lalrpop
@@ -53,6 +53,7 @@ extern {
     ":" => Token::Colon,
     "->" => Token::Arrow,
     "," => Token::Coma,
+    "#" => Token::Hashtag,
     "<" => Token::LessThanSign,
     ">" => Token::MoreThanSign,
     ">=" => Token::MoreThanEqSign,
@@ -118,6 +119,14 @@ PlusSeparated<T>: Vec<T> = {
         }
     }
 };
+
+List<T>: Vec<T> = {
+  <T> => vec![<>],
+  <mut s:List<T>> <n:T> => {
+      s.push(n);
+      s
+  },
+}
 
 // Requires the semicolon at end
 SemiColonSeparated<T>: Vec<T> = {
@@ -291,13 +300,22 @@ pub(crate) Param: ast::functions::Param = {
   }
 }
 
+pub(crate) Attribute: ast::common::Attribute = {
+  <lo:@L> "#" "[" <name:"identifier"> <value:("=" <"string">)?> "]" <hi:@R> => ast::common::Attribute {
+    name,
+    value,
+    span: ast::common::Span::new(lo, hi),
+  }
+}
+
 pub(crate) FunctionDecl: ast::functions::FunctionDecl = {
-  <lo:@L> <is_pub:"pub"?> <is_extern:"extern"?>
+  <lo:@L> <attributes:List<Attribute>?> <is_pub:"pub"?> <is_extern:"extern"?>
       "fn" <name:Ident> <generic_params:GenericParams?> "(" <params:Comma<Param>> ")"
         <ret_type:FunctionRetType?> <hi:@R> =>
     ast::functions::FunctionDecl {
         doc_string: None,
         generic_params: generic_params.unwrap_or(vec![]),
+        attributes: attributes.unwrap_or(vec![]),
         name,
         params,
         ret_type,

--- a/crates/concrete_parser/src/lib.rs
+++ b/crates/concrete_parser/src/lib.rs
@@ -290,4 +290,15 @@ mod ModuleName {
         let parser = grammar::ProgramParser::new();
         parser.parse(lexer).unwrap();
     }
+
+    #[test]
+    fn parse_intrinsic() {
+        let source = r##"mod MyMod {
+    #[intrinsic = "simdsomething"]
+    pub extern fn myintrinsic();
+}"##;
+        let lexer = Lexer::new(source);
+        let parser = grammar::ProgramParser::new();
+        parser.parse(lexer).unwrap();
+    }
 }

--- a/crates/concrete_parser/src/tokens.rs
+++ b/crates/concrete_parser/src/tokens.rs
@@ -109,6 +109,8 @@ pub enum Token {
     Coma,
     #[token(".")]
     Dot,
+    #[token("#")]
+    Hashtag,
     #[token("<")]
     LessThanSign,
     #[token(">")]

--- a/examples/hello_world_hacky.con
+++ b/examples/hello_world_hacky.con
@@ -1,0 +1,36 @@
+mod HelloWorld {
+    pub extern fn malloc(size: u64) -> *mut u8;
+    pub extern fn puts(data: *mut u8) -> i32;
+
+    fn main() -> i32 {
+        let origin: *mut u8 = malloc(12);
+        let mut p: *mut u8 = origin;
+
+        *p = 'H';
+        p = p + 1;
+        *p = 'e';
+        p = p + 1;
+        *p = 'l';
+        p = p + 1;
+        *p = 'l';
+        p = p + 1;
+         *p = 'o';
+        p = p + 1;
+         *p = ' ';
+        p = p + 1;
+         *p = 'W';
+        p = p + 1;
+         *p = 'o';
+        p = p + 1;
+         *p = 'r';
+        p = p + 1;
+         *p = 'l';
+        p = p + 1;
+         *p = 'd';
+        p = p + 1;
+        *p = '\0';
+        puts(origin);
+
+        return 0;
+    }
+}


### PR DESCRIPTION

Added the ability to offset a pointer, this allows us to do the following:
```rust
mod HelloWorld {
    pub extern fn malloc(size: u64) -> *mut u8;
    pub extern fn puts(data: *mut u8) -> i32;

    fn main() -> i32 {
        let origin: *mut u8 = malloc(12);
        let mut p: *mut u8 = origin;

        *p = 'H';
        p = p + 1;
        *p = 'e';
        p = p + 1;
        *p = 'l';
        p = p + 1;
        *p = 'l';
        p = p + 1;
         *p = 'o';
        p = p + 1;
         *p = ' ';
        p = p + 1;
         *p = 'W';
        p = p + 1;
         *p = 'o';
        p = p + 1;
         *p = 'r';
        p = p + 1;
         *p = 'l';
        p = p + 1;
         *p = 'd';
        p = p + 1;
        *p = '\0';
        puts(origin);

        return 0;
    }
}
```

Which prints "Hello World"

Also added the ability to add attributes to functions, and declare intrinsics:
```rust
mod MyMod {
    #[intrinsic = "simdsomething"]
    pub extern fn myintrinsic();
}
```