### PR TITLE
testcases in concrete_driver examples includes check phase for linearity check coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto  # Automatically sets the target based on the previous commits
+        threshold: 0% # Allows any decrease in coverage without failing the check
+        base: auto
+    patch:
+      default:
+        target: auto  # Automatically sets the target based on the previous commits
+        threshold: 0% # Allows any decrease in coverage without failing the check
+        base: auto

--- a/crates/concrete_check/src/linearity_check.rs
+++ b/crates/concrete_check/src/linearity_check.rs
@@ -752,23 +752,23 @@ impl LinearityChecker {
                 Ok(state_tbl)
             }
             Statement::Return(return_stmt) => {
-                if let Some(return_stmt) = &return_stmt.value{
-                    state_tbl = self.check_expr(state_tbl, depth, &return_stmt, "return")?;
+                if let Some(return_stmt) = &return_stmt.value {
+                    state_tbl = self.check_expr(state_tbl, depth, return_stmt, "return")?;
                 }
                 // Ensure that all variables are properly consumed
                 for (name, var_info) in state_tbl.vars.iter() {
                     match var_info.state {
-                        VarState::Consumed => (),  // If consumed, no action needed
+                        VarState::Consumed => (), // If consumed, no action needed
                         _ => match var_info.ty {
-                           // Type::WriteRef(_) | Type::SpanMut(_) => (),  // These can be dropped implicitly
+                            // Type::WriteRef(_) | Type::SpanMut(_) => (),  // These can be dropped implicitly
                             _ if self.is_universe_linear_ish(&var_info.ty) => {
                                 // Collect error if a variable that needs to be consumed hasn't been
                                 errors.push(LinearityError::VariableNotConsumed {
-                                    variable: name.clone(),                                    
+                                    variable: name.clone(),
                                 });
-                            },
-                            _ => ()
-                        }
+                            }
+                            _ => (),
+                        },
                     }
                 }
                 if !errors.is_empty() {

--- a/crates/concrete_check/src/linearity_check.rs
+++ b/crates/concrete_check/src/linearity_check.rs
@@ -268,15 +268,13 @@ impl LinearityChecker {
         context: &str,
     ) -> Result<StateTbl, LinearityError> {
         // Assuming you have a method to get all variable names and types
-        //let vars = &mut self.state_tbl.vars;
-        //TODO check if we can avoid cloning
         let vars = state_tbl.vars.clone();
         println!("Check_expr vars {:?}", vars);
         for (name, _info) in vars.iter() {
             //self.check_var_in_expr(depth, &name, &info.ty, expr)?;
             state_tbl = self
                 .check_var_in_expr(state_tbl, depth, name, expr, context)
-                .unwrap();
+                .expect("Linearity error");
         }
         Ok(state_tbl)
     }

--- a/crates/concrete_check/src/linearity_check.rs
+++ b/crates/concrete_check/src/linearity_check.rs
@@ -923,7 +923,7 @@ impl LinearityChecker {
 pub fn linearity_check_program(
     programs: &Vec<(PathBuf, String, Program)>,
     _session: &Session,
-) -> Result<String, LinearityError> {
+) -> Result<(), LinearityError> {
     tracing::debug!("Starting linearity check");
     let checker = LinearityChecker::new();
     for (_path, name, program) in programs {
@@ -992,5 +992,5 @@ pub fn linearity_check_program(
             }
         }
     }
-    Ok("OK".to_string())
+    Ok(())
 }

--- a/crates/concrete_check/src/linearity_check/errors.rs
+++ b/crates/concrete_check/src/linearity_check/errors.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub enum LinearityError {
     #[error("Variable {variable} not consumed")]
     NotConsumed { variable: String },

--- a/crates/concrete_check/src/linearity_check/errors.rs
+++ b/crates/concrete_check/src/linearity_check/errors.rs
@@ -24,6 +24,8 @@ pub enum LinearityError {
     UnhandledStateOrCount { variable: String },
     #[error("Consumed variable {variable} in loop created outside the loop")]
     ConsumedVariableInLoop { variable: String },
+    #[error("Variable {variable} not consumed")]
+    VariableNotConsumed{variable: String},
     #[error("Unspecified Linearity error. Variable {variable} generated {message}")]
     Unspecified { variable: String, message: String },
     #[error("Variable {variable} not found")]

--- a/crates/concrete_check/src/linearity_check/errors.rs
+++ b/crates/concrete_check/src/linearity_check/errors.rs
@@ -25,7 +25,7 @@ pub enum LinearityError {
     #[error("Consumed variable {variable} in loop created outside the loop")]
     ConsumedVariableInLoop { variable: String },
     #[error("Variable {variable} not consumed")]
-    VariableNotConsumed{variable: String},
+    VariableNotConsumed { variable: String },
     #[error("Unspecified Linearity error. Variable {variable} generated {message}")]
     Unspecified { variable: String, message: String },
     #[error("Variable {variable} not found")]

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -12,6 +12,7 @@ use concrete_session::{
     Session,
 };
 use config::{Package, Profile};
+use core::panic;
 use db::Database;
 use git2::{IndexAddOption, Repository};
 use owo_colors::OwoColorize;
@@ -605,15 +606,14 @@ pub fn compile(args: &CompilerArgs) -> Result<PathBuf> {
 
     #[allow(unused_variables)]
     if args.check {
-        let linearity_result =
-            match concrete_check::linearity_check::linearity_check_program(&programs, &session) {
-                Ok(ir) => ir,
-                Err(error) => {
-                    //TODO improve reporting
-                    println!("Linearity check failed: {:#?}", error);
-                    std::process::exit(1);
-                }
-            };
+        //let linearity_result =
+        match concrete_check::linearity_check::linearity_check_program(&programs, &session) {
+            Ok(ir) => ir,
+            Err(error) => {
+                //TODO improve reporting
+                panic!("Linearity check failed: {:#?}", error);
+            }
+        };
     }
 
     if args.ir {

--- a/crates/concrete_driver/src/lib.rs
+++ b/crates/concrete_driver/src/lib.rs
@@ -110,18 +110,18 @@ pub struct BuildArgs {
 #[command(author, version, about = "concrete compiler", long_about = None)]
 pub struct CompilerArgs {
     /// The input file.
-    input: PathBuf,
+    pub input: PathBuf,
 
     /// The output file.
     pub output: PathBuf,
 
     /// Build for release with all optimizations.
     #[arg(short, long, default_value_t = false)]
-    release: bool,
+    pub release: bool,
 
     /// Set the optimization level, 0,1,2,3
     #[arg(short = 'O', long)]
-    optlevel: Option<u8>,
+    pub optlevel: Option<u8>,
 
     /// Always add debug info
     #[arg(long)]
@@ -129,35 +129,35 @@ pub struct CompilerArgs {
 
     /// Build as a library.
     #[arg(short, long, default_value_t = false)]
-    library: bool,
+    pub library: bool,
 
     /// Also output the ast.
     #[arg(long, default_value_t = false)]
-    ast: bool,
+    pub ast: bool,
 
     /// Also output the ir.
     #[arg(long, default_value_t = false)]
-    ir: bool,
+    pub ir: bool,
 
     /// Also output the llvm ir file.
     #[arg(long, default_value_t = false)]
-    llvm: bool,
+    pub llvm: bool,
 
     /// Also output the mlir file
     #[arg(long, default_value_t = false)]
-    mlir: bool,
+    pub mlir: bool,
 
     /// Also output the asm file.
     #[arg(long, default_value_t = false)]
-    asm: bool,
+    pub asm: bool,
 
     /// Also output the object file.
     #[arg(long, default_value_t = false)]
-    object: bool,
+    pub object: bool,
 
     /// This option is for checking the program for linearity.
     #[arg(long, default_value_t = false)]
-    check: bool,
+    pub check: bool,
 }
 
 pub fn main() -> Result<()> {

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -35,7 +35,6 @@ pub struct CompileResult {
     pub binary_file: PathBuf,
 }
 
-
 pub fn compile_program(
     source: &str,
     name: &str,
@@ -43,7 +42,7 @@ pub fn compile_program(
     optlevel: OptLevel,
 ) -> Result<CompileResult, Box<dyn std::error::Error>> {
     // TODO need to implement to build CompilerArgs for testing with options
-    /* 
+    /*
     let mut input_path = std::env::current_dir()?;
     input_path.join(source);
     let build_dir = std::env::current_dir()?;

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -129,7 +129,7 @@ pub fn compile_program_with_args(
     let mut linearity_errors = Vec::new();
     //#[allow(unused_variables)]
     if args.check {
-        let _linearity_result = match concrete_check::linearity_check::linearity_check_program(
+        match concrete_check::linearity_check::linearity_check_program(
             &programs_for_check,
             &session,
         ) {
@@ -194,7 +194,8 @@ pub fn compile_and_run(source: &str, name: &str, library: bool, optlevel: OptLev
     output.status.code().unwrap()
 }
 
-#[cfg(test)]
+#[allow(unused)] // false positive
+//#[cfg(test)] //TODO It should solve the warning but it doesn't
 #[track_caller]
 pub fn compile_and_run_with_args(
     source: &str,

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -193,13 +193,18 @@ pub fn compile_and_run(source: &str, name: &str, library: bool, optlevel: OptLev
 }
 
 #[track_caller]
-pub fn compile_and_run_with_args(source: &str, name: &str, library: bool, optlevel: OptLevel, args: &CompilerArgs) -> Result<Output, std::io::Error>  {
-    let result = compile_program_with_args(source, name, library, optlevel, args).expect("failed to compile");
-    //let result = compile_program_with_args(source, name, library, optlevel, args);
-    let output = run_program(&result.binary_file).expect("failed to run");
-    //output.status.code().unwrap()
-    Ok(output)
-
+pub fn compile_and_run_with_args(source: &str, name: &str, library: bool, optlevel: OptLevel, args: &CompilerArgs) -> 
+//Result<Output, std::io::Error>  {
+    Result<Output, Box<dyn std::error::Error>>{
+    let compile_result = compile_program_with_args(source, name, library, optlevel, args);
+    match compile_result {
+        //Err(e) => Err(std::error::Error::new(std::io::ErrorKind::Other, e.to_string())),
+        Err(e) => Err(e),
+        Ok(result) => {
+            let run_output = run_program(&result.binary_file)?;
+            Ok(run_output)
+        }
+    }
 }
 
 #[allow(unused)] // false positive

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -159,7 +159,7 @@ pub fn compile_program_with_args(
             &session.output_file.with_extension(""),
         )?;
     }
-    if linearity_errors.len() > 0 {
+    if !linearity_errors.is_empty() {
         let error = build_test_linearity_error(&linearity_errors[0]);
         Err(error)
     } else {
@@ -176,7 +176,7 @@ pub fn build_test_linearity_error(
 ) -> Box<dyn std::error::Error> {
     let mut ret = "Linearity check failed<".to_string();
     ret.push_str(&linearity_error.to_string());
-    ret.push_str(">");
+    ret.push('>');
     Box::new(TestError(ret.into()))
 }
 
@@ -194,6 +194,7 @@ pub fn compile_and_run(source: &str, name: &str, library: bool, optlevel: OptLev
     output.status.code().unwrap()
 }
 
+#[cfg(test)]
 #[track_caller]
 pub fn compile_and_run_with_args(
     source: &str,

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -64,89 +64,6 @@ pub fn compile_program(
     compile_program_with_args(source, name, library, optlevel, &compile_args)
 }
 
-/* 
-pub fn compile_program(
-    source: &str,
-    name: &str,
-    library: bool,
-    optlevel: OptLevel,
-) -> Result<CompileResult, Box<dyn std::error::Error>> {
-    let db = concrete_driver::db::Database::default();
-    let source = ProgramSource::new(&db, source.to_string(), name.to_string());
-    tracing::debug!("source code:\n{}", source.input(&db));
-    let mut program = match concrete_parser::parse_ast(&db, source) {
-        Some(x) => x,
-        None => {
-            Diagnostics::dump(
-                &db,
-                source,
-                &concrete_parser::parse_ast::accumulated::<concrete_parser::error::Diagnostics>(
-                    &db, source,
-                ),
-            );
-            return Err(Box::new(TestError("error compiling".into())));
-        }
-    };
-
-    let test_dir = tempfile::tempdir()?;
-    let test_dir_path = test_dir.path();
-
-    let input_file = test_dir_path.join(name).with_extension("con");
-    println!("*");
-    println!("*");
-    println!("*");
-    println!("*");
-    println!("input file: {:?}", input_file);
-    
-    std::fs::write(&input_file, source.input(&db))?;
-    program.file_path = Some(input_file.clone());
-
-    let output_file = test_dir_path.join(name);
-    let output_file = if library {
-        output_file.with_extension(Session::get_platform_library_ext())
-    } else if cfg!(target_os = "windows") {
-        output_file.with_extension("exe")
-    } else {
-        output_file.with_extension("")
-    };
-
-    let session = Session {
-        debug_info: DebugInfo::Full,
-        optlevel,
-        sources: vec![Source::from(source.input(&db).to_string())],
-        library,
-        output_file,
-        output_mlir: false,
-        output_ll: false,
-        output_asm: false,
-        file_paths: vec![input_file],
-    };
-
-    let program_ir = lower_programs(&[program])?;
-
-    let object_path = concrete_codegen_mlir::compile(&session, &program_ir)?;
-
-    if library {
-        link_shared_lib(
-            &[object_path.clone()],
-            &session
-                .output_file
-                .with_extension(Session::get_platform_library_ext()),
-        )?;
-    } else {
-        link_binary(
-            &[object_path.clone()],
-            &session.output_file.with_extension(""),
-        )?;
-    }
-
-    Ok(CompileResult {
-        folder: test_dir,
-        object_file: object_path,
-        binary_file: session.output_file,
-    })
-}
-*/
 
 pub fn compile_program_with_args(
     source: &str,
@@ -162,7 +79,6 @@ pub fn compile_program_with_args(
     let real_source = source.to_string();
     let source = ProgramSource::new(&db, source.to_string(), name.to_string());
     tracing::debug!("source code:\n{}", source.input(&db));
-    //println!("source code:\n{}", source.input(&db));    
     let mut program = match concrete_parser::parse_ast(&db, source) {
         Some(x) => x,
         None => {
@@ -176,20 +92,11 @@ pub fn compile_program_with_args(
             return Err(Box::new(TestError("error compiling".into())));
         }
     };
-    //println!("program: {:?}", program);    
     
     let test_dir = tempfile::tempdir()?;
     let test_dir_path = test_dir.path();
 
     let input_file = test_dir_path.join(name).with_extension("con");
-    println!("*");
-    println!("*");
-    println!("*");
-    println!("*");
-    
-    println!("input file: {:?}", input_file);
-    
-    //println!("After read_to_string: {:?}", real_source);
     
     //Build Vec for programs_for_check before moving program
     if args.check {

--- a/crates/concrete_driver/tests/common.rs
+++ b/crates/concrete_driver/tests/common.rs
@@ -7,6 +7,8 @@ use std::{
 
 use ariadne::Source;
 use concrete_driver::linker::{link_binary, link_shared_lib};
+// TODO uncomment when CompilerArgs tests calls are functional
+//use concrete_driver::CompilerArgs;
 use concrete_ir::lowering::lower_programs;
 use concrete_parser::{error::Diagnostics, ProgramSource};
 use concrete_session::{
@@ -33,12 +35,48 @@ pub struct CompileResult {
     pub binary_file: PathBuf,
 }
 
+
 pub fn compile_program(
     source: &str,
     name: &str,
     library: bool,
     optlevel: OptLevel,
 ) -> Result<CompileResult, Box<dyn std::error::Error>> {
+    // TODO need to implement to build CompilerArgs for testing with options
+    /* 
+    let mut input_path = std::env::current_dir()?;
+    input_path.join(source);
+    let build_dir = std::env::current_dir()?;
+    let output = build_dir.join(source);
+
+    let compile_args = CompilerArgs {
+        input: input_path.clone(),
+        output: output.clone(),
+        false,
+        optlevel: None,
+        debug_info: None,
+        library: lib,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+    };
+    */
+    //compile_program_with_args(source, name, library, optlevel, &compile_args);
+    compile_program_with_args(source, name, library, optlevel)
+}
+
+pub fn compile_program_with_args(
+    source: &str,
+    name: &str,
+    library: bool,
+    optlevel: OptLevel,
+    //args: &CompilerArgs,
+) -> Result<CompileResult, Box<dyn std::error::Error>> {
+    //TODO run parser with CompilerArgs
     let db = concrete_driver::db::Database::default();
     let source = ProgramSource::new(&db, source.to_string(), name.to_string());
     tracing::debug!("source code:\n{}", source.input(&db));
@@ -119,7 +157,6 @@ pub fn run_program(program: &Path) -> Result<Output, std::io::Error> {
 #[track_caller]
 pub fn compile_and_run(source: &str, name: &str, library: bool, optlevel: OptLevel) -> i32 {
     let result = compile_program(source, name, library, optlevel).expect("failed to compile");
-
     let output = run_program(&result.binary_file).expect("failed to run");
 
     output.status.code().unwrap()

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -22,9 +22,31 @@ mod common;
 #[test_case(include_str!("../../../examples/for_while.con"), "for_while", false, 10 ; "for_while.con")]
 #[test_case(include_str!("../../../examples/arrays.con"), "arrays", false, 5 ; "arrays.con")]
 #[test_case(include_str!("../../../examples/linearExample01.con"), "linearity", false, 2 ; "linearExample01.con")]
-#[test_case(include_str!("../../../examples/linearExample02.con"), "linearity", false, 2 ; "linearExample02.con")]
-#[test_case(include_str!("../../../examples/linearExample03if.con"), "linearity", false, 0 ; "linearExample03if.con")]
 fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
+    assert_eq!(
+        status_code,
+        compile_and_run(source, name, is_library, OptLevel::None)
+    );
+    assert_eq!(
+        status_code,
+        compile_and_run(source, name, is_library, OptLevel::Less)
+    );
+    assert_eq!(
+        status_code,
+        compile_and_run(source, name, is_library, OptLevel::Default)
+    );
+    assert_eq!(
+        status_code,
+        compile_and_run(source, name, is_library, OptLevel::Aggressive)
+    );
+}
+
+#[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
+#[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
+#[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
+fn example_tests_with_options(source: &str,  options: &str, name: &str, is_library: bool, status_code: i32) {
+    // TODO need compile_and_run with Options for using args
+    let _args = [options];
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::None)

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -46,9 +46,9 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
 }
 
 
-//#[test_case(include_str!("../../../examples/linearExample01.con"),  "linearity", false, 2; "linearExample01.con")]
-//#[test_case(include_str!("../../../examples/linearExample02.con"), "linearity", false, 2 ; "linearExample02.con")]
-//#[test_case(include_str!("../../../examples/linearExample03if.con"),  "linearity", false, 0 ; "linearExample03if.con")]
+#[test_case(include_str!("../../../examples/linearExample01.con"),  "linearity", false, 2; "linearExample01.con")]
+#[test_case(include_str!("../../../examples/linearExample02.con"), "linearity", false, 2 ; "linearExample02.con")]
+#[test_case(include_str!("../../../examples/linearExample03if.con"),  "linearity", false, 0 ; "linearExample03if.con")]
 fn example_tests_with_check(
     source: &str,
     name: &str,
@@ -87,103 +87,33 @@ fn example_tests_with_args(
     
     let not_consumed_xy_error = build_test_linearity_error(&LinearityError::VariableNotConsumed {variable: "xy".to_string()});
 
-    let compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
+    //let compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
     let result_1 = compile_and_run_with_args(source, name, is_library, OptLevel::None, &compile_args);
     match result_1 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
-        //Err(e) => assert_eq!(not_consumed_xy_error, e),
-        Err(_e) => assert_eq!(1, 1),
+        Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
-    /* 
-    let _compile_result_2 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Less, &compile_args);
-    assert_eq!(
-        expected_status_code,
-        compile_and_run_with_args(source, name, is_library, OptLevel::Less, &compile_args)
-    );
-    let _compile_result_3 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Default, &compile_args);
-    assert_eq!(
-        expected_status_code,
-        compile_and_run_with_args(source, name, is_library, OptLevel::Default, &compile_args)
-    );
-    let _compile_result_4 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
-    assert_eq!(
-        expected_status_code,
-        compile_and_run_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args)
-    );
-    */
-    match compile_result{
-        Ok(_compile_result) => {
-            Ok(())
-        }
-        Err(err) => {
-            Err(err)
-        }
+    let result_2 = compile_and_run_with_args(source, name, is_library, OptLevel::Less, &compile_args);
+    match result_2 {
+        Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
+        Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
-}
-
-
-#[allow(dead_code)]
-//TODO Implement to interpret options
-//#[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
-//#[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
-//#[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
-fn _example_tests_with_options(
-    source: &str,
-    options: &str,
-    name: &str,
-    is_library: bool,
-    status_code: i32    
-) -> Result<(), Box<dyn std::error::Error>> {
-    let _args = [options];
-    let mut input_path = std::env::current_dir()?;
-    input_path = input_path.join(source);
-    let build_dir = std::env::current_dir()?;
-    let output = build_dir.join(source);
-    let compile_args = CompilerArgs {
-        input: input_path.clone(),
-        output: output.clone(),
-        release: false,
-        ast: false,
-        optlevel: None,
-        debug_info: None,
-        library: false,
-        ir: false,
-        llvm: false,
-        mlir: false,
-        asm: false,
-        object: false,
-        check: true,
-    };
     
-    let compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
-    assert_eq!(
-        status_code,
-        compile_and_run(source, name, is_library, OptLevel::None)
-    );
-    let _compile_result_2 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Less, &compile_args);
-    assert_eq!(
-        status_code,
-        compile_and_run(source, name, is_library, OptLevel::Less)
-    );
-    let _compile_result_3 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Default, &compile_args);
-    assert_eq!(
-        status_code,
-        compile_and_run(source, name, is_library, OptLevel::Default)
-    );
-    let _compile_result_4 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
-    assert_eq!(
-        status_code,
-        compile_and_run(source, name, is_library, OptLevel::Aggressive)
-    );
-    match compile_result{
-        Ok(_compile_result) => {
-            Ok(())
-        }
-        Err(err) => {
-            Err(err)
-        }
+    let result_3 = compile_and_run_with_args(source, name, is_library, OptLevel::Default, &compile_args);
+    match result_3 {
+        Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
+        Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
+    
+    let result_4 = compile_and_run_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
+    match result_4 {
+        Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
+        Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
+    }
+    Ok(())
 }
+
+
 
 #[test_case(include_str!("../../../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
 #[test_case(include_str!("../../../examples/hello_world_array.con"), "hello_world_array", false, "hello world!\n" ; "hello_world_array.con")]

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -107,13 +107,8 @@ fn example_tests_with_args(
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
 
-    let result_4 = compile_and_run_with_args(
-        source,
-        name,
-        is_library,
-        OptLevel::Aggressive,
-        &compile_args,
-    );
+    let result_4 = 
+        compile_and_run_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
     match result_4 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -1,6 +1,9 @@
 use crate::common::{compile_and_run, compile_and_run_output};
+//use crate::common::{compile_and_run, compile_and_run_output, CompileResult};
+//use concrete_driver::CompilerArgs;
 use concrete_session::config::OptLevel;
 use test_case::test_case;
+
 
 mod common;
 
@@ -21,7 +24,6 @@ mod common;
 #[test_case(include_str!("../../../examples/for.con"), "for", false, 10 ; "for.con")]
 #[test_case(include_str!("../../../examples/for_while.con"), "for_while", false, 10 ; "for_while.con")]
 #[test_case(include_str!("../../../examples/arrays.con"), "arrays", false, 5 ; "arrays.con")]
-#[test_case(include_str!("../../../examples/linearExample01.con"), "linearity", false, 2 ; "linearExample01.con")]
 fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     assert_eq!(
         status_code,
@@ -41,6 +43,9 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     );
 }
 
+
+//TODO uncomment for implement example_test_with_options
+/* 
 #[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
 #[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
 #[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
@@ -50,26 +55,73 @@ fn example_tests_with_options(
     name: &str,
     is_library: bool,
     status_code: i32,
-) {
+) -> Result<CompileResult, Box<dyn std::error::Error>>{
     // TODO need compile_and_run with Options for using args
     let _args = [options];
+
+    let mut input_path = std::env::current_dir()?;
+    input_path = input_path.join(source);
+    let build_dir = std::env::current_dir()?;
+    let output = build_dir.join(source);
+
+    //TODO derive compile_args from _args string
+    let compile_args = CompilerArgs {
+        input: input_path.clone(),
+        output: output.clone(),
+        release: false,
+        ast: false,
+        optlevel: None,
+        debug_info: None,
+        library: false,
+        ir: false,
+        llvm: false,
+        mlir: false,
+        asm: false,
+        object: false,
+        check: true,
+    };
+    let mut compile_result: Result<CompileResult, Box<dyn std::error::Error>>;
+    compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::None)
     );
+    match compile_result {
+        Ok(_compile_result) => {
+            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Less, &compile_args);
+        }
+        Err(_e1) => {
+        }
+    }
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Less)
     );
+    match compile_result {
+        Ok(_compile_result) => {
+            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Default, &compile_args);
+        }
+        Err(_e2) => {
+        }
+    }
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Default)
     );
+    match compile_result {
+        Ok(_compile_result) => {
+            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
+        }
+        Err(_e3) => {
+        }
+    }
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Aggressive)
     );
+    compile_result
 }
+*/
 
 #[test_case(include_str!("../../../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
 #[test_case(include_str!("../../../examples/hello_world_array.con"), "hello_world_array", false, "hello world!\n" ; "hello_world_array.con")]

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -44,7 +44,13 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
 #[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
 #[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
 #[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
-fn example_tests_with_options(source: &str,  options: &str, name: &str, is_library: bool, status_code: i32) {
+fn example_tests_with_options(
+    source: &str,
+    options: &str,
+    name: &str,
+    is_library: bool,
+    status_code: i32,
+) {
     // TODO need compile_and_run with Options for using args
     let _args = [options];
     assert_eq!(

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -5,7 +5,6 @@ use concrete_driver::CompilerArgs;
 use concrete_session::config::OptLevel;
 use test_case::test_case;
 
-
 mod common;
 
 #[test_case(include_str!("../../../examples/borrow.con"), "borrow", false, 2 ; "borrow.con")]
@@ -45,7 +44,6 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     );
 }
 
-
 #[test_case(include_str!("../../../examples/linearExample01.con"),  "linearity", false, 2; "linearExample01.con")]
 #[test_case(include_str!("../../../examples/linearExample02.con"), "linearity", false, 2 ; "linearExample02.con")]
 #[test_case(include_str!("../../../examples/linearExample03if.con"),  "linearity", false, 0 ; "linearExample03if.con")]
@@ -82,38 +80,46 @@ fn example_tests_with_args(
     name: &str,
     is_library: bool,
     expected_status_code: i32,
-    compile_args: CompilerArgs
+    compile_args: CompilerArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    
-    let not_consumed_xy_error = build_test_linearity_error(&LinearityError::VariableNotConsumed {variable: "xy".to_string()});
+    let not_consumed_xy_error = build_test_linearity_error(&LinearityError::VariableNotConsumed {
+        variable: "xy".to_string(),
+    });
 
     //let compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
-    let result_1 = compile_and_run_with_args(source, name, is_library, OptLevel::None, &compile_args);
+    let result_1 =
+        compile_and_run_with_args(source, name, is_library, OptLevel::None, &compile_args);
     match result_1 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
-    let result_2 = compile_and_run_with_args(source, name, is_library, OptLevel::Less, &compile_args);
+    let result_2 =
+        compile_and_run_with_args(source, name, is_library, OptLevel::Less, &compile_args);
     match result_2 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
-    
-    let result_3 = compile_and_run_with_args(source, name, is_library, OptLevel::Default, &compile_args);
+
+    let result_3 =
+        compile_and_run_with_args(source, name, is_library, OptLevel::Default, &compile_args);
     match result_3 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
-    
-    let result_4 = compile_and_run_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
+
+    let result_4 = compile_and_run_with_args(
+        source,
+        name,
+        is_library,
+        OptLevel::Aggressive,
+        &compile_args,
+    );
     match result_4 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
     Ok(())
 }
-
-
 
 #[test_case(include_str!("../../../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
 #[test_case(include_str!("../../../examples/hello_world_array.con"), "hello_world_array", false, "hello world!\n" ; "hello_world_array.con")]

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -107,8 +107,13 @@ fn example_tests_with_args(
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),
     }
 
-    let result_4 = 
-        compile_and_run_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
+    let result_4 = compile_and_run_with_args(
+        source,
+        name,
+        is_library,
+        OptLevel::Aggressive,
+        &compile_args,
+    );
     match result_4 {
         Ok(output) => assert_eq!(expected_status_code, output.status.code().unwrap()),
         Err(e) => assert_eq!(not_consumed_xy_error.to_string(), e.to_string()),

--- a/crates/concrete_driver/tests/examples.rs
+++ b/crates/concrete_driver/tests/examples.rs
@@ -1,6 +1,5 @@
 use crate::common::{compile_and_run, compile_and_run_output};
-//use crate::common::{compile_and_run, compile_and_run_output, CompileResult};
-//use concrete_driver::CompilerArgs;
+use concrete_driver::CompilerArgs;
 use concrete_session::config::OptLevel;
 use test_case::test_case;
 
@@ -25,9 +24,6 @@ mod common;
 #[test_case(include_str!("../../../examples/for_while.con"), "for_while", false, 10 ; "for_while.con")]
 #[test_case(include_str!("../../../examples/arrays.con"), "arrays", false, 5 ; "arrays.con")]
 #[test_case(include_str!("../../../examples/constants.con"), "constants", false, 20 ; "constants.con")]
-#[test_case(include_str!("../../../examples/linearExample01.con"), "linearity", false, 2 ; "linearExample01.con")]
-#[test_case(include_str!("../../../examples/linearExample02.con"), "linearity", false, 2 ; "linearExample02.con")]
-#[test_case(include_str!("../../../examples/linearExample03if.con"), "linearity", false, 0 ; "linearExample03if.con")]
 fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
     assert_eq!(
         status_code,
@@ -48,27 +44,27 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
 }
 
 
-//TODO uncomment for implement example_test_with_options
-/* 
-#[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
-#[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
-#[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
+#[allow(dead_code)]
+//TODO uncomment for running example_test_with_options
+//#[test_case(include_str!("../../../examples/linearExample01.con"), "--check", "linearity", false, 2; "linearExample01.con")]
+//#[test_case(include_str!("../../../examples/linearExample02.con"), "--check", "linearity", false, 2 ; "linearExample02.con")]
+//#[test_case(include_str!("../../../examples/linearExample03if.con"), "--check", "linearity", false, 0 ; "linearExample03if.con")]
 fn example_tests_with_options(
     source: &str,
     options: &str,
     name: &str,
     is_library: bool,
     status_code: i32,
-) -> Result<CompileResult, Box<dyn std::error::Error>>{
-    // TODO need compile_and_run with Options for using args
+//) -> Result<CompileResult, Box<dyn std::error::Error>>{
+) -> Result<(), Box<dyn std::error::Error>> {
     let _args = [options];
-
     let mut input_path = std::env::current_dir()?;
     input_path = input_path.join(source);
     let build_dir = std::env::current_dir()?;
     let output = build_dir.join(source);
 
     //TODO derive compile_args from _args string
+    //By now fix check manually
     let compile_args = CompilerArgs {
         input: input_path.clone(),
         output: output.clone(),
@@ -84,48 +80,35 @@ fn example_tests_with_options(
         object: false,
         check: true,
     };
-    let mut compile_result: Result<CompileResult, Box<dyn std::error::Error>>;
-    compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
+    let compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::None, &compile_args);
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::None)
     );
-    match compile_result {
-        Ok(_compile_result) => {
-            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Less, &compile_args);
-        }
-        Err(_e1) => {
-        }
-    }
+    let _compile_result_2 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Less, &compile_args);
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Less)
     );
-    match compile_result {
-        Ok(_compile_result) => {
-            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Default, &compile_args);
-        }
-        Err(_e2) => {
-        }
-    }
+    let _compile_result_3 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Default, &compile_args);
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Default)
     );
-    match compile_result {
-        Ok(_compile_result) => {
-            compile_result = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
-        }
-        Err(_e3) => {
-        }
-    }
+    let _compile_result_4 = crate::common::compile_program_with_args(source, name, is_library, OptLevel::Aggressive, &compile_args);
     assert_eq!(
         status_code,
         compile_and_run(source, name, is_library, OptLevel::Aggressive)
     );
-    compile_result
+    match compile_result{
+        Ok(_compile_result) => {
+            Ok(())
+        }
+        Err(err) => {
+            Err(err)
+        }
+    }
 }
-*/
 
 #[test_case(include_str!("../../../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
 #[test_case(include_str!("../../../examples/hello_world_array.con"), "hello_world_array", false, "hello world!\n" ; "hello_world_array.con")]


### PR DESCRIPTION
It can be checked in [codecov](https://app.codecov.io/github/lambdaclass/concrete/commit/16fd6e773d48aa56fd3bb4fd917d0aefc1ff54fc/blob/crates/concrete_check/src/linearity_check.rs) we are now covering linearity_check.rs source file. 

Linearity check algorithm can be aknowledged as completed when fn check_var_in_expr coverage of match statement is fully covered. It is expected to cover not with examples .con file, but manually building the conditions for coverage, as the current status of the parser is possible not to satisfy all conditions from a parsed source code.
