### PR TITLE
Fix typo installation.md

### DIFF
--- a/docs/book/src/installation.md
+++ b/docs/book/src/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Currently Concrete is distrubted via source only, so you will have to compile it:
+Currently Concrete is distributed via source only, so you will have to compile it:
 
 ```bash
 git clone https://github.com/lambdaclass/concrete.git


### PR DESCRIPTION
# Fix Typo in `installation.md`

## Description
This pull request fixes a typo in the `installation.md` file:  
- Corrected "distrubted" to "distributed" for proper spelling.
