### PR TITLE
Make importing structs work

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,20 @@ mod StructExample {
         baz: i64,
     }
 
+    impl Foo {
+        pub fn mul_bar(&mut self, value: i32) {
+            self.bar = self.bar * 2;
+        }
+    }
+
     fn main() -> i32 {
         let mut foo: Foo = Foo {
             bar: 2,
             baz: 3,
         };
 
-        foo.bar = foo.bar * 2;
+        foo.mul_bar(2);
+        foo.baz = foo.baz * 5;
 
         return get_foo_field_by_borrow(&foo) + foo.bar;
     }
@@ -178,10 +185,12 @@ mod Option {
         Some(T),
     }
 
-    pub fn map<A, B>(opt: Option<A>, f: A -> B) -> Option<B> {
-        match opt {
-            None -> None,
-            Some(x) -> Some(f(x)),
+    impl<A> Option<A> {
+        pub fn map<A, B>(self, f: A -> B) -> Option<B> {
+            match self {
+                None -> None,
+                Some(x) -> Some(f(x)),
+            }
         }
     }
 }
@@ -202,7 +211,7 @@ The design was very heavily influenced by all these programming languages:
 - [Erlang](https://www.erlang.org) (Preemptive scheduler, message passing, runtime)
 - [Rust](https://www.rust-lang.org/) (Syntax, features, low-level focus)
 - [Commonware](https://commonware.xyz/blogs/commonware-runtime.html) (Deterministic runtime)
-- [Austral](https://austral-lang.org/spec/spec.html) (Linear type system) 
+- [Austral](https://austral-lang.org/spec/spec.html) (Linear type system)
 - [Pony](https://www.ponylang.io) / [Gleam](https://gleam.run) (Typed message passing)
 - [Go](https://go.dev) (Preemptive scheduler)
 - [Loom](https://github.com/tokio-rs/loom) (Concurrency permutation testing for Rust)

--- a/examples/import_struct.con
+++ b/examples/import_struct.con
@@ -1,0 +1,21 @@
+mod A {
+    struct X {
+        a: i32
+    }
+
+    fn hello(x: X) -> i32 {
+        return x.a;
+    }
+}
+
+mod ImportStruct {
+    import A.{X, hello};
+
+    pub fn main() -> i32 {
+        let x: X = X {
+            a: 2,
+        };
+
+        return hello(x);
+    }
+}

--- a/examples/import_struct_impl.con
+++ b/examples/import_struct_impl.con
@@ -1,0 +1,23 @@
+mod A {
+    struct X {
+        a: i32
+    }
+
+    impl X {
+        fn mul(&self, other: i32) -> i32 {
+            return self.a * other;
+        }
+    }
+}
+
+mod Example {
+    import A.{X};
+
+    pub fn main() -> i32 {
+        let x: X = X {
+            a: 2,
+        };
+
+        return x.mul(4);
+    }
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -9,6 +9,7 @@ mod common;
 #[test_case(include_str!("../examples/fib_if.con"), "fib_if", false, 55 ; "fib_if.con")]
 #[test_case(include_str!("../examples/import.con"), "import", false, 12 ; "import.con")]
 #[test_case(include_str!("../examples/import_struct.con"), "import_struct", false, 2 ; "import_struct.con")]
+#[test_case(include_str!("../examples/import_struct_impl.con"), "import_struct_impl", false, 8 ; "import_struct_impl.con")]
 #[test_case(include_str!("../examples/impl_block.con"), "impl_block", false, 8 ; "impl_block.con")]
 #[test_case(include_str!("../examples/impl_block_mut.con"), "impl_block_mut", false, 4 ; "impl_block_mut.con")]
 #[test_case(include_str!("../examples/simple.con"), "simple", false, 8 ; "simple.con")]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -8,6 +8,7 @@ mod common;
 #[test_case(include_str!("../examples/factorial_if.con"), "factorial_if", false, 24 ; "factorial_if.con")]
 #[test_case(include_str!("../examples/fib_if.con"), "fib_if", false, 55 ; "fib_if.con")]
 #[test_case(include_str!("../examples/import.con"), "import", false, 12 ; "import.con")]
+#[test_case(include_str!("../examples/import_struct.con"), "import_struct", false, 2 ; "import_struct.con")]
 #[test_case(include_str!("../examples/impl_block.con"), "impl_block", false, 8 ; "impl_block.con")]
 #[test_case(include_str!("../examples/impl_block_mut.con"), "impl_block_mut", false, 4 ; "impl_block_mut.con")]
 #[test_case(include_str!("../examples/simple.con"), "simple", false, 8 ; "simple.con")]


### PR DESCRIPTION
```rust
mod A {
    struct X {
        a: i32
    }

    fn hello(x: X) -> i32 {
        return x.a;
    }
}

mod ImportStruct {
    import A.{X, hello};

    pub fn main() -> i32 {
        let x: X = X {
            a: 2,
        };

        return hello(x);
    }
}
```

```rust
mod A {
    struct X {
        a: i32
    }

    impl X {
        fn mul(&self, other: i32) -> i32 {
            return self.a * other;
        }
    }
}

mod Example {
    import A.{X};

    pub fn main() -> i32 {
        let x: X = X {
            a: 2,
        };

        return x.mul(4);
    }
}
```