### PR TITLE
Fix if with literals

### DIFF
--- a/examples/if_with_literals.con
+++ b/examples/if_with_literals.con
@@ -1,0 +1,9 @@
+mod IfLit {
+    pub fn main() -> i32 {
+        if 5 > 1 {
+            return 1;
+        } else {
+            return 2;
+        }
+    }
+}

--- a/src/ir/lowering.rs
+++ b/src/ir/lowering.rs
@@ -15,6 +15,7 @@ use crate::ast::{
     Program,
 };
 use common::{BuildCtx, FnBodyBuilder, IdGenerator};
+use tracing::debug;
 
 use crate::ir::{
     AdtBody, BasicBlock, BinOp, ConcreteIntrinsic, ConstBody, ConstData, ConstKind, ConstValue,
@@ -1525,11 +1526,21 @@ fn lower_binary_op(
     type_hint: Option<Ty>,
 ) -> Result<(Rvalue, Ty, Span), LoweringError> {
     let (lhs, lhs_ty, lhs_span) = if type_hint.is_none() {
-        let ty = find_expression_type(builder, lhs).unwrap_or_else(|| {
-            find_expression_type(builder, rhs).expect(
-                "couldn't find the expression type, this shouldnt happen and it's a compiler bug",
-            )
-        });
+        let ty = find_expression_type(builder, lhs).or_else(|| find_expression_type(builder, rhs));
+
+        let ty = if let Some(ty) = ty {
+            ty
+        } else {
+            // Default to i32 if cant infer type.
+            // Should be ok because at other points if the i32 doesn't match the expected type
+            // a error will be thrown, forcing user to specify types.
+            debug!("can't infer type, defaulting to i32");
+            Ty {
+                span: None,
+                kind: TyKind::Int(IntTy::I32),
+            }
+        };
+
         lower_expression(builder, lhs, Some(ty))?
     } else {
         lower_expression(builder, lhs, type_hint.clone())?

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -6,6 +6,7 @@ mod common;
 
 #[test_case(include_str!("../examples/borrow.con"), "borrow", false, 2 ; "borrow.con")]
 #[test_case(include_str!("../examples/variable_inside_if.con"), "variable_inside_if", false, 16 ; "variable_inside_if.con")]
+#[test_case(include_str!("../examples/if_with_literals.con"), "if_with_literals", false, 1 ; "if_with_literals.con")]
 #[test_case(include_str!("../examples/factorial_if.con"), "factorial_if", false, 24 ; "factorial_if.con")]
 #[test_case(include_str!("../examples/fib_if.con"), "fib_if", false, 55 ; "fib_if.con")]
 #[test_case(include_str!("../examples/import.con"), "import", false, 12 ; "import.con")]


### PR DESCRIPTION
The problem was that it couldn't infer a type due to lack of info. Now it defaults to i32, like rust.

Fixes #173 