### PR TITLE
Initial String support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,12 +118,30 @@ jobs:
               uses: taiki-e/install-action@cargo-llvm-cov
             - name: test and generate coverage
               run: make coverage
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
+            - name: save coverage data
+              uses: actions/upload-artifact@v4
               with:
-                token: ${{ secrets.CODECOV_TOKEN }}
-                files: lcov.info
-                fail_ci_if_error: true
+                name: coverage-data
+                path: ./lcov.info
+    upload-coverage:
+      name: Upload Coverage
+      runs-on: ubuntu-latest
+      needs: [coverage]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Download coverage artifacts
+          uses: actions/download-artifact@v4
+          with:
+            name: coverage-data
+        - name: Upload coverage
+          uses: codecov/codecov-action@v4
+          with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+            files: ./lcov.info
+            fail_ci_if_error: true
+            verbose: true
+
     bench:
       name: Bench
       runs-on: ubuntu-latest

--- a/examples/hello_world.con
+++ b/examples/hello_world.con
@@ -1,0 +1,18 @@
+mod hello {
+    extern fn malloc(size: u64) -> *mut u8;
+    extern fn puts(ptr: *mut u8) -> i32;
+
+    #[langitem = "String"]
+    struct String {
+        ptr: *mut u8,
+        len: u64,
+        cap: u64,
+    }
+
+    fn main() -> u64 {
+        let x: String = "hello \nworld!";
+        puts(x.ptr);
+
+        return 0;
+    }
+}

--- a/src/ast/structs.rs
+++ b/src/ast/structs.rs
@@ -1,5 +1,5 @@
 use super::{
-    common::{GenericParam, Ident, Span},
+    common::{Attribute, GenericParam, Ident, Span},
     types::TypeDescriptor,
 };
 
@@ -7,6 +7,7 @@ use super::{
 pub struct StructDecl {
     pub name: Ident,
     pub generics: Vec<GenericParam>,
+    pub attributes: Vec<Attribute>,
     pub fields: Vec<Field>,
     pub is_pub: bool,
     pub span: Span,

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -306,5 +306,17 @@ pub fn lowering_error_to_report(error: LoweringError) -> Report<'static, FileSpa
             }
             report.finish()
         }
+        LoweringError::UnknownLangItem { span, item, path } => {
+            let path = path.display().to_string();
+            let filespan = FileSpan::new(path.clone(), span.from..span.to);
+            let report = Report::build(ReportKind::Error, filespan.clone())
+                .with_code("UnknownLangItem")
+                .with_label(
+                    Label::new(filespan.clone())
+                        .with_message(format!("unknown lang item '{}'", item))
+                        .with_color(colors.next()),
+                );
+            report.finish()
+        }
     }
 }

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -5,7 +5,7 @@ use crate::ir::{
     ModuleIndex, Operand, Place, PlaceElem, Rvalue, Span, Type as IRType, TypeIndex, ValueTree, IR,
 };
 use ariadne::Source;
-use melior::helpers::ArithBlockExt;
+use melior::helpers::{ArithBlockExt, BuiltinBlockExt, GepIndex, LlvmBlockExt};
 use melior::ir::{BlockLike, RegionLike};
 use melior::{
     dialect::{
@@ -1310,6 +1310,7 @@ fn value_tree_to_int(value: &ValueTree) -> Option<i64> {
             crate::ir::ConstValue::U128(value) => Some((*value) as i64),
             crate::ir::ConstValue::F32(_) => None,
             crate::ir::ConstValue::F64(_) => None,
+            crate::ir::ConstValue::String(_) => None,
         },
         ValueTree::Branch(_) => None,
     }
@@ -1323,6 +1324,57 @@ fn compile_value_tree<'c: 'b, 'b>(
 ) -> Result<Value<'c, 'b>, CodegenError> {
     Ok(match value {
         ValueTree::Leaf(value) => match value {
+            crate::ir::ConstValue::String(data) => {
+                let location = Location::unknown(ctx.context());
+                let ty = compile_type(ctx.module, &IRType::String);
+                let len = data.len();
+                let u64_ty = IntegerType::new(ctx.context(), 64).into();
+                let u8_ty = IntegerType::new(ctx.context(), 8).into();
+                // + 1 for the null byte.
+                let len_value =
+                    block.const_int_from_type(ctx.context(), location, len + 1, u64_ty)?;
+
+                let arr_ty = llvm::r#type::array(u8_ty, len as u32);
+
+                let constant = block.append_op_result(
+                    ods::llvm::mlir_constant(
+                        ctx.context(),
+                        arr_ty,
+                        StringAttribute::new(ctx.context(), data).into(),
+                        location,
+                    )
+                    .into(),
+                )?;
+
+                let ptr = block.append_op_result(func::call(
+                    ctx.context(),
+                    FlatSymbolRefAttribute::new(ctx.context(), "malloc"),
+                    &[len_value],
+                    &[llvm::r#type::pointer(ctx.context(), 0)],
+                    location,
+                ))?;
+
+                block.store(ctx.context(), location, ptr, constant)?;
+                let ptr_off = block.gep(
+                    ctx.context(),
+                    location,
+                    ptr,
+                    &[GepIndex::Const(len as i32)],
+                    u8_ty,
+                )?;
+                // add the null byte.
+                let const_0 = block.const_int(ctx.context(), location, 0, 64)?;
+                block.store(ctx.context(), location, ptr_off, const_0)?;
+
+                let struct_value = block.append_op_result(llvm::undef(ty, location))?;
+
+                block.insert_values(
+                    ctx.context(),
+                    location,
+                    struct_value,
+                    &[ptr, len_value, len_value],
+                )?
+            }
             crate::ir::ConstValue::Bool(value) => block
                 .append_operation(arith::constant(
                     ctx.context(),
@@ -1473,7 +1525,16 @@ fn compile_type<'c>(ctx: ModuleCodegenCtx<'c>, ty: &IRType) -> Type<'c> {
             crate::ir::FloatTy::F32 => Type::float32(ctx.ctx.mlir_context),
             crate::ir::FloatTy::F64 => Type::float64(ctx.ctx.mlir_context),
         },
-        crate::ir::Type::String => todo!(),
+        crate::ir::Type::String => {
+            let ty = *ctx
+                .ctx
+                .program
+                .builtin_types
+                .get(&crate::ir::Type::String)
+                .unwrap();
+            let ty = ctx.get_type(ty);
+            compile_type(ctx, &ty)
+        }
         crate::ir::Type::Array(inner_type_idx, length) => {
             let inner_type = ctx.get_type(*inner_type_idx);
             let inner_type = compile_type(ctx, &inner_type);

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -401,10 +401,12 @@ StructField: ast::structs::Field = {
     }
 }
 
+
 StructDef: ast::structs::StructDecl = {
-    <lo:@L> <is_pub:"pub"?> "struct" <name:Ident> <generics:GenericParams?> "{" <fields:Comma<StructField>> "}" <hi:@R> => ast::structs::StructDecl {
+    <lo:@L> <attributes:List<Attribute>?> <is_pub:"pub"?> "struct" <name:Ident> <generics:GenericParams?> "{" <fields:Comma<StructField>> "}" <hi:@R> => ast::structs::StructDecl {
         name,
         fields,
+        attributes: attributes.unwrap_or_default(),
         is_pub: is_pub.is_some(),
         generics: generics.unwrap_or(vec![]),
         span: Span::new(lo, hi),

--- a/src/ir/lowering/errors.rs
+++ b/src/ir/lowering/errors.rs
@@ -95,4 +95,10 @@ pub enum LoweringError {
         needs: usize,
         path: PathBuf,
     },
+    #[error("unknown lang item {item}")]
+    UnknownLangItem {
+        span: Span,
+        item: String,
+        path: PathBuf,
+    },
 }

--- a/src/ir/lowering/expressions.rs
+++ b/src/ir/lowering/expressions.rs
@@ -737,7 +737,15 @@ pub(crate) fn lower_value_expr(
 
             (Rvalue::Use(Operand::Const(data)), ty)
         }
-        ValueExpr::ConstStr(_, _) => todo!(),
+        ValueExpr::ConstStr(value, span) => {
+            let ty = fn_builder.builder.ir.get_string_ty();
+            let data = ConstData {
+                ty,
+                span: *span,
+                data: ConstKind::Value(ValueTree::Leaf(ConstValue::String(value.clone()))),
+            };
+            (Rvalue::Use(Operand::Const(data)), ty)
+        }
         ValueExpr::Path(info) => {
             if fn_builder.name_to_local.contains_key(&info.first.name) {
                 let (place, place_ty, _span) = lower_path(fn_builder, info)?;

--- a/src/ir/lowering/lower.rs
+++ b/src/ir/lowering/lower.rs
@@ -220,7 +220,11 @@ fn lower_module_symbols(
                                 builder.ir.builtin_types.insert(Type::String, type_idx);
                             }
                             _ => {
-                                panic!("unknown lang item: {:?}", langitem)
+                                return Err(LoweringError::UnknownLangItem {
+                                    span: attr.span,
+                                    item: attr.name.clone(),
+                                    path: builder.get_current_module().file_path.clone(),
+                                });
                             }
                         }
                     }

--- a/src/ir/lowering/lower.rs
+++ b/src/ir/lowering/lower.rs
@@ -210,6 +210,22 @@ fn lower_module_symbols(
                 builder.ir.modules[module_idx].types.insert(type_idx);
                 builder.struct_to_type_idx.insert(idx, type_idx);
                 builder.type_to_module.insert(type_idx, module_idx);
+
+                for attr in &struct_decl.attributes {
+                    if attr.name == "langitem" {
+                        let langitem = attr.value.as_ref().unwrap();
+
+                        match langitem.as_str() {
+                            "String" => {
+                                builder.ir.builtin_types.insert(Type::String, type_idx);
+                            }
+                            _ => {
+                                panic!("unknown lang item: {:?}", langitem)
+                            }
+                        }
+                    }
+                }
+
                 debug!(
                     "Adding struct symbol {:?} to module {:?}",
                     struct_decl.name.name, module.name.name

--- a/src/ir/lowering/types.rs
+++ b/src/ir/lowering/types.rs
@@ -65,7 +65,7 @@ pub(crate) fn lower_type(
                 .get(&Type::Float(FloatTy::F64))
                 .unwrap(),
             "bool" => *builder.ir.builtin_types.get(&Type::Bool).unwrap(),
-            "string" => *builder.ir.builtin_types.get(&Type::String).unwrap(),
+            "String" => *builder.ir.builtin_types.get(&Type::String).unwrap(),
             "char" => *builder.ir.builtin_types.get(&Type::Char).unwrap(),
             other => {
                 // Check if the type name exists in the generic map.

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -853,6 +853,7 @@ pub enum ConstValue {
     U128(u128),
     F32(String),
     F64(String),
+    String(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -129,5 +129,5 @@ pub fn compile_and_run_output(
 
     let output = run_program(&result.binary_file).expect("failed to run");
 
-    std::str::from_utf8(&output.stdout).unwrap().to_string()
+    String::from_utf8_lossy(&output.stdout).to_string()
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -60,6 +60,7 @@ fn example_tests(source: &str, name: &str, is_library: bool, status_code: i32) {
 
 #[test_case(include_str!("../examples/hello_world_hacky.con"), "hello_world_hacky", false, "Hello World\n" ; "hello_world_hacky.con")]
 #[test_case(include_str!("../examples/hello_world_array.con"), "hello_world_array", false, "hello world!\n" ; "hello_world_array.con")]
+#[test_case(include_str!("../examples/hello_world.con"), "hello_world", false, "hello \nworld!\n" ; "hello_world.con")]
 fn example_tests_with_output(source: &str, name: &str, is_library: bool, result: &str) {
     assert_eq!(
         result,


### PR DESCRIPTION
Adds initial support for strings, for now all are heap allocated to make things simple.

```rust

mod hello {
    extern fn malloc(size: u64) -> *mut u8;
    extern fn puts(ptr: *mut u8) -> i32;

    #[langitem = "String"]
    struct String {
        ptr: *mut u8,
        len: u64,
        cap: u64,
    }

    fn main() -> u64 {
        let x: String = "hello \nworld!";
        puts(x.ptr);

        return 0;
    }
}
```