### PR TITLE
Initial dependencies support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ build/
 *.ir
 
 .vscode/
+
+.stones/

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ build/
 
 .vscode/
 
-.stones/
+.bricks/

--- a/examples/project/Concrete.toml
+++ b/examples/project/Concrete.toml
@@ -12,3 +12,6 @@ debug_info = false
 release = false
 opt_level = 0
 debug_info = true
+
+[dependencies]
+std = { path = "../../std", version = "0.1.0" }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use modules::Module;
 
 pub mod common;
@@ -16,6 +14,5 @@ pub mod types;
 /// A compile represents a whole package, made up of various modules.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompilationUnit {
-    pub file_path: PathBuf,
     pub modules: Vec<Module>,
 }

--- a/src/driver/config.rs
+++ b/src/driver/config.rs
@@ -34,10 +34,14 @@ pub struct Profile {
 }
 
 /// Defines a package dependency
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct Dependency {
-    /// The (relative or absolute) path to the dependency. (Currently only supports paths)
-    pub path: PathBuf,
+    /// The (relative or absolute) path to the dependency.
+    pub path: Option<PathBuf>,
+    /// The git repository to the dependency
+    pub git: Option<String>,
+    /// The git commit to use.
+    pub r#ref: Option<String>,
     /// The version of the dependency.
-    pub version: String,
+    pub version: Option<String>,
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -225,7 +225,6 @@ GenericParams: Vec<ast::common::GenericParam> = {
 pub CompilationUnit: ast::CompilationUnit = {
   <Module> => {
     ast::CompilationUnit {
-      file_path: file_path.to_path_buf(),
       modules: vec![<>],
     }
   },

--- a/src/ir/lowering/functions.rs
+++ b/src/ir/lowering/functions.rs
@@ -224,8 +224,10 @@ pub(crate) fn lower_func(
 
     for attr in &func.decl.attributes {
         if attr.name.as_str() == "test" {
-            builder.ir.tests.push(fn_id);
             // TODO: check its a valid test function, i.e: no arguments, returns a i32.
+            if builder.context.add_tests {
+                builder.ir.tests.push(fn_id);
+            }
             break;
         }
     }

--- a/src/ir/lowering/mod.rs
+++ b/src/ir/lowering/mod.rs
@@ -102,6 +102,8 @@ pub struct IRBuilder {
 
 #[derive(Debug, Clone)]
 pub struct IRBuilderContext {
+    /// Whether to save the test functions found.
+    pub add_tests: bool,
     /// The type used to resolve "self".
     pub self_ty: Option<TypeIndex>,
     /// The current name to type index mapping to resolve generic type names in the current context.

--- a/std/src/string.con
+++ b/std/src/string.con
@@ -18,6 +18,10 @@ mod string {
             return value;
         }
 
+        pub fn len(&self) -> u64 {
+            return self.len;
+        }
+
         pub fn get(&self, at: u64) -> char {
             // todo: bounds check
             let target_ptr: *mut u8 = self.ptr + self.len;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -39,7 +39,7 @@ pub fn compile_program(
 ) -> Result<CompileResult, Box<dyn std::error::Error>> {
     let source = ProgramSource::new(source.to_string(), Path::new(""));
     tracing::debug!("source code:\n{}", &source.input);
-    let mut program = match concrete::parser::parse_ast(&source) {
+    let program = match concrete::parser::parse_ast(&source) {
         Ok(x) => x,
         Err(_) => {
             return Err(Box::new(TestError("error compiling".into())));
@@ -51,7 +51,6 @@ pub fn compile_program(
 
     let input_file = test_dir_path.join(name).with_extension(".con");
     std::fs::write(&input_file, &source.input)?;
-    program.file_path = input_file.clone();
 
     let output_file = test_dir_path.join(name);
     let output_file = if library {


### PR DESCRIPTION
Allows specifying dependencies either as a path or a git repo (http)

Example toml

```toml
[package]
name = "project"
version = "0.1.0"
license = "MIT"

[profile.release]
release = true
opt_level = 3
debug_info = false

[profile.dev]
release = false
opt_level = 0
debug_info = true

[dependencies]
std = { path = "/data2/edgar/work/concrete/std", version = "0.1.0" }
concrete_example = { git = "https://github.com/edg-l/testrepo.git", ref = "749914161b22f8cd0e62b04c67e6bd5fcf9074ea" }
```

The git dependencies are cloned under the .bricks subdir.

The project main.con

```rust
mod project {
    mod other;

    import other.{hello};
    import std.io.{print};

    pub fn main() -> u32 {
        let x: String = "hello world";
        print(&x);
        let y: u32 = x.len() as u32;
        return hello(y);
    }
}
```

```
├── Concrete.toml
└── src
    ├── main.con
    └── other.con
```

This allows projects to use the std by specifying it as a dependency.

Current drawback, it's all one compile unit in llvm meaning we can't currently paralellize when doing codegen with llvm. I intentionally leave this for the future because it's hard to deal with, specially with resolving types across crates, like generics.

Future early improvements:
- A prelude
- Better dependency deduplication