### PR TITLE
docs: fix minor typos in documentation

### DIFF
--- a/docs/book/src/internal/builder.md
+++ b/docs/book/src/internal/builder.md
@@ -1,6 +1,6 @@
 # The IR builder
 
-This struct is used during the building of the IR, it holds structures needed only temporarely while building.
+This struct is used during the building of the IR, it holds structures needed only temporarily while building.
 
 Some of these structures are:
 

--- a/docs/book/src/internal/ir.md
+++ b/docs/book/src/internal/ir.md
@@ -1,6 +1,6 @@
 # The Concrete IR
 
-Currently in Concrete, the AST is lowered first to a IR to help support multiple targets and ease the generation of code on the end of the compilation process.
+Currently in Concrete, the AST is lowered first to an IR to help support multiple targets and ease the generation of code on the end of the compilation process.
 
 This IR is based on the concept of basic blocks, where within each block there is a linear flow (i.e) there is no branching.
 


### PR DESCRIPTION
A couple of small typos in the docs and fixed them:  

- **docs/book/src/internal/builder.md**: "temporarely" → "temporarily"  
- **docs/book/src/internal/ir.md**: "to a IR" → "to an IR"  
