### PR TITLE
Fix make build in macos: export LIBRARY_PATH

### DIFF
--- a/scripts/env-macos.sh
+++ b/scripts/env-macos.sh
@@ -3,6 +3,7 @@
 # This script is only useful on macOS using brew.
 # It sets the LLVM environment variables.
 
+export LIBRARY_PATH=/opt/homebrew/lib
 export MLIR_SYS_190_PREFIX="$(brew --prefix llvm@19)"
 export LLVM_SYS_191_PREFIX="$(brew --prefix llvm@19)"
 export TABLEGEN_190_PREFIX="$(brew --prefix llvm@19)"


### PR DESCRIPTION
When running `make build` in Macos (with brew), I encountered the following error:

```
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: warning: ignoring duplicate libraries: '-lm'
          ld: library 'zstd' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Exporting `LIBRARY_PATH` seems to fix the issue.