### PR TITLE
Fix outdated code examples

### DIFF
--- a/examples/enum.con
+++ b/examples/enum.con
@@ -6,12 +6,18 @@ mod EnumExample {
     }
 
     fn main() -> i32 {
-        let mut foo: Foo = Foo.Bar;
+        let mut foo: Foo = Foo#Bar;
 
 		match foo {
-			Foo.Bar -> return 1;,
-			Foo.Baz -> return 2;,
-			Foo.Qux -> return 3;,
+			Foo#Bar => {
+			    return 1;
+			},
+			Foo#Baz => {
+			    return 2;
+			},
+			Foo#Qux => {
+			    return 3;
+			},
 		}
     }
 }

--- a/examples/for_loop.con
+++ b/examples/for_loop.con
@@ -6,12 +6,14 @@ mod Example {
     fn sum_to(limit: i64) -> i64 {
         let mut result: i64 = 0;
 
-        let n: i64 = 1;
+        let mut n: i64 = 1;
         for {
+            if n > 10 {
+                // there is no break yet
+                return result;
+            }
             result = result + n;
             n = n + 1;
         }
-
-        return result;
     }
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -37,6 +37,7 @@ mod common;
 #[test_case(include_str!("../examples/malloc.con"), "malloc", false, 5 ; "malloc.con")]
 #[test_case(include_str!("../examples/while_if_false.con"), "while_if_false", false, 7 ; "while_if_false.con")]
 #[test_case(include_str!("../examples/if_if_false.con"), "if_if_false", false, 7 ; "if_if_false.con")]
+#[test_case(include_str!("../examples/for_loop.con"), "for_loop", false, 55 ; "for_loop.con")]
 #[test_case(include_str!("../examples/for_loop_var.con"), "for", false, 0 ; "for_loop_var.con")]
 #[test_case(include_str!("../examples/for.con"), "for", false, 10 ; "for.con")]
 #[test_case(include_str!("../examples/for_while.con"), "for_while", false, 10 ; "for_while.con")]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -7,6 +7,7 @@ mod common;
 #[test_case(include_str!("../examples/type_alias.con"), "type_alias", false, 4 ; "type_alias.con")]
 #[test_case(include_str!("../examples/simple_trait.con"), "simple_trait", false, 2 ; "simple_trait.con")]
 #[test_case(include_str!("../examples/generic_enum_impl.con"), "generic_enum_impl", false, 1 ; "generic_enum_impl.con")]
+#[test_case(include_str!("../examples/enum.con"), "enum", false, 1 ; "enum.con")]
 #[test_case(include_str!("../examples/enum_match.con"), "enum_match", false, 2 ; "enum_match.con")]
 #[test_case(include_str!("../examples/direct_module_use.con"), "direct_module_use", false, 6 ; "direct_module_use.con")]
 #[test_case(include_str!("../examples/sizeof_intrinsic.con"), "foo", false, 5 ; "sizeof_intrinsic.con")]


### PR DESCRIPTION
This PR fixes some outdated code examples.

The following examples are still failing, because support for them has yet not been implemented:

- examples/factorial.con
- examples/union.con

What should we do with these files? Should we move them to another directory `examples/unimplemented`?

Also, the example `examples/check_error.con` fails, but given its name maybe its on purpose. Should be move it another directory `examples/failing`?

